### PR TITLE
refactor : 이메일 검증 시 string 기준으로 검증하도록 수정

### DIFF
--- a/src/main/java/com/project/syncly/domain/auth/email/EmailAuthServiceImpl.java
+++ b/src/main/java/com/project/syncly/domain/auth/email/EmailAuthServiceImpl.java
@@ -55,7 +55,7 @@ public class EmailAuthServiceImpl implements EmailAuthService {
     @Override
     public void saveCode(String email, String code) {
         String key = RedisKeyPrefix.EMAIL_AUTH_CODE.get(email);
-        redisStorage.set(key, code, Duration.ofSeconds(codeTtlSeconds));
+        redisStorage.setValueAsString(key, code, Duration.ofSeconds(codeTtlSeconds));
     }
 
 
@@ -74,7 +74,7 @@ public class EmailAuthServiceImpl implements EmailAuthService {
     @Override
     public void markVerified(String email) {
         String key = RedisKeyPrefix.EMAIL_AUTH_VERIFIED.get(email);
-        redisStorage.set(key, "true", Duration.ofSeconds(verifiedTtlSeconds));
+        redisStorage.setValueAsString(key, "true", Duration.ofSeconds(verifiedTtlSeconds));
     }
 
 


### PR DESCRIPTION
# ☝️Issue Number

- # 32

##  📌 개요

- redis 중 string 저장받는 로직들은 StringRedisTemplate 사용하도록 리팩토링하면서, 저장할때는 사용하도록 수정하지 않은 로직들 사용하도록 재 변경하면서 set은 변경하지 않아 발생했던 문제 해결

## 🔁 변경 사항
- emailAuthService

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점