### PR TITLE
refactor : cookie key 통일 및, 허용 도메인에 배포 스웨거 추가

### DIFF
--- a/src/main/java/com/project/syncly/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/project/syncly/domain/auth/service/AuthServiceImpl.java
@@ -10,6 +10,7 @@ import com.project.syncly.domain.member.repository.MemberRepository;
 import com.project.syncly.global.jwt.JwtProvider;
 import com.project.syncly.global.jwt.dto.IssuedTokens;
 import com.project.syncly.global.jwt.dto.RefreshClaims;
+import com.project.syncly.global.jwt.enums.TokenType;
 import com.project.syncly.global.jwt.exception.JwtErrorCode;
 import com.project.syncly.global.jwt.exception.JwtException;
 import jakarta.servlet.http.Cookie;
@@ -38,7 +39,7 @@ public class AuthServiceImpl implements AuthService {
     private final JwtProvider jwtProvider;
     private final RefreshWhitelistService whitelist;
 
-    private static final String REFRESH_COOKIE = "REFRESH";
+    private static final String REFRESH_COOKIE = TokenType.REFRESH.toString();
     private static final String REFRESH_COOKIE_PATH = "/api/auth";
 
 


### PR DESCRIPTION
# ☝️Issue Number

- # 32

##  📌 개요

- csrf 검사 시, 허용하는 도메인에 배포 스웨거 추가
- cookie key 하나의 enum으로 통일

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

> 추후에 프론트 배포하면 프론트 도메인 추가해야합니다!