### PR TITLE
refactor : nginx 라우팅이 백엔드는 api/로 시작하도록 설정했으므로, 기본 url를 api로 시작하도록 변경

### DIFF
--- a/src/main/java/com/project/syncly/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/syncly/global/config/SecurityConfig.java
@@ -69,8 +69,8 @@ public class SecurityConfig {
     @Order(1)
     SecurityFilterChain oauth2Chain(HttpSecurity http) throws Exception {
         http
-                .securityMatcher("/oauth2/**",//클라이언트 초기 접속 api (GET /oauth2/authorization/{registrationId})
-                        "/login/oauth2/**")//구글에서 우리서버 redirect url (GET /login/oauth2/code/{registrationId})
+                .securityMatcher("/api/oauth2/**",//클라이언트 초기 접속 api (GET /oauth2/authorization/{registrationId})
+                        "/api/login/oauth2/**")//구글에서 우리서버 redirect url (GET /login/oauth2/code/{registrationId})
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(Customizer.withDefaults())
                 .formLogin(AbstractHttpConfigurer::disable)
@@ -79,6 +79,8 @@ public class SecurityConfig {
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
                 .authorizeHttpRequests(a -> a.anyRequest().permitAll())
                 .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(a -> a.baseUri("/api/oauth2/authorization"))  // 시작 URL 변경
+                        .redirectionEndpoint(r -> r.baseUri("/api/login/oauth2/code/*"))     // 콜백 URL 변경
                         .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
                         .successHandler(oauth2SuccessHandler)
                         .failureHandler(oauth2FailureHandler)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,7 +37,7 @@ spring:
           google:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
-            redirect-uri: "https://www.syncly-io.com/login/oauth2/code/google"
+            redirect-uri: "https://www.syncly-io.com/api/login/oauth2/code/google"
             authorization-grant-type: authorization_code
             scope:
               - profile     #이름, 프로필 이미지


### PR DESCRIPTION
# ☝️Issue Number

- # 49

##  📌 개요

-nginx 설정에 맞춰서 oauth 시작 url 변경

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점