### PR TITLE
Refactor/#49  이메일 인증 비번 변경 api의 경우 로그아웃 상태임을 상정하여 요청 dto에 이메일을 받는 방식으로 수정

### DIFF
--- a/src/main/java/com/project/syncly/domain/member/controller/MemberController.java
+++ b/src/main/java/com/project/syncly/domain/member/controller/MemberController.java
@@ -131,9 +131,8 @@ public class MemberController {
             description = "이메일 인증을 통해 비밀번호를 변경하는 API입니다."
     )
     @PatchMapping("/password/email")
-    public ResponseEntity<CustomResponse<Void>> updatePasswordWithEmail(@RequestBody @Valid MemberRequestDTO.UpdatePasswordWithEmail updatePassword,
-                                                               @MemberIdInfo Long memberId) {
-        memberCommandService.updatePasswordWithEmail(updatePassword, memberId);
+    public ResponseEntity<CustomResponse<Void>> updatePasswordWithEmail(@RequestBody @Valid MemberRequestDTO.UpdatePasswordWithEmail updatePassword) {
+        memberCommandService.updatePasswordWithEmail(updatePassword);
         return ResponseEntity.ok(CustomResponse.success(HttpStatus.OK));
     }
 

--- a/src/main/java/com/project/syncly/domain/member/dto/request/MemberRequestDTO.java
+++ b/src/main/java/com/project/syncly/domain/member/dto/request/MemberRequestDTO.java
@@ -38,6 +38,7 @@ public class MemberRequestDTO {
 
     @PasswordMatch
     public record UpdatePasswordWithEmail(
+            @Email @NotBlank String email,
             @ValidPassword String newPassword,
             @NotBlank String confirmPassword
     )implements PasswordPair {}

--- a/src/main/java/com/project/syncly/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/project/syncly/domain/member/service/MemberCommandService.java
@@ -12,7 +12,7 @@ public interface MemberCommandService {
     public Member findOrCreateSocialMember(String email, String name, SocialLoginProvider provider);
     public void updateName(MemberRequestDTO.UpdateName updateName, Long memberId);
     public void updatePassword(MemberRequestDTO.UpdatePassword updatePassword, Long memberId);
-    void updatePasswordWithEmail(MemberRequestDTO.UpdatePasswordWithEmail updatePassword, Long memberId);
+    void updatePasswordWithEmail(MemberRequestDTO.UpdatePasswordWithEmail updatePassword);
     public void updateProfileImage(Long memberId, S3RequestDTO.UpdateFile request);
     public void deleteProfileImage(Long memberId);
     public void deleteMember(HttpServletRequest request, HttpServletResponse response,

--- a/src/main/java/com/project/syncly/domain/member/service/impl/MemberCommandServiceImpl.java
+++ b/src/main/java/com/project/syncly/domain/member/service/impl/MemberCommandServiceImpl.java
@@ -145,8 +145,8 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     }
 
     @Override
-    public void updatePasswordWithEmail(MemberRequestDTO.UpdatePasswordWithEmail updatePassword, Long memberId) {
-        Member member = memberRepository.findById(memberId)
+    public void updatePasswordWithEmail(MemberRequestDTO.UpdatePasswordWithEmail updatePassword) {
+        Member member = memberRepository.findByEmail(updatePassword.email())
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         if (member.getSocialLoginProvider() != SocialLoginProvider.LOCAL) {

--- a/src/main/java/com/project/syncly/domain/s3/util/CloudFrontUtil.java
+++ b/src/main/java/com/project/syncly/domain/s3/util/CloudFrontUtil.java
@@ -18,7 +18,8 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-
+/// signed cookie 공식문서
+/// https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-setting-signed-cookie-custom-policy.html?utm_source=chatgpt.com
 @Component
 @RequiredArgsConstructor
 public class CloudFrontUtil {
@@ -32,11 +33,22 @@ public class CloudFrontUtil {
     @Value("${aws.cloudfront.private-key}")
     private String privateKeyBase64;
 
+    private static String toUrlSafe(String b64) {
+        return b64.replace('+','-').replace('=','_').replace('/','~');
+    }
+
+    // 1) MIME Base64 인코딩(개행 제거) + URL-safe
+    private static String mimeBase64UrlSafe(byte[] bytes) {
+        String b64 = Base64.getMimeEncoder().encodeToString(bytes);
+        // 혹시 들어간 줄바꿈 제거
+        b64 = b64.replace("\n","").replace("\r","");
+        return toUrlSafe(b64);
+    }
     public Map<String, String> generateSignedCookies(String resourcePath, Duration duration) {
         try {
             Date expiresAt = new Date(System.currentTimeMillis() + duration.toMillis());
 
-            String policy = String.format("""
+            String policyPretty  = String.format("""
                 {
                   "Statement": [
                     {
@@ -50,14 +62,15 @@ public class CloudFrontUtil {
                   ]
                 }
                 """, cloudFrontDomain, resourcePath, expiresAt.getTime() / 1000);
-
+            //공백제거
+            String policy = policyPretty.replaceAll("\\s+", "");
             // 정책을 RSA로 서명
             PrivateKey privateKey = loadPrivateKey(privateKeyBase64);
             String signature = signWithPrivateKey(policy, privateKey);
 
             // 쿠키 생성
             Map<String, String> cookies = new HashMap<>();
-            cookies.put("CloudFront-Policy", Base64.getEncoder().encodeToString(policy.getBytes(StandardCharsets.UTF_8)));
+            cookies.put("CloudFront-Policy", mimeBase64UrlSafe(policy.getBytes(StandardCharsets.UTF_8)));
             cookies.put("CloudFront-Signature", signature);
             cookies.put("CloudFront-Key-Pair-Id", keyPairId);
 
@@ -93,10 +106,10 @@ public class CloudFrontUtil {
 
 
     private String signWithPrivateKey(String data, PrivateKey privateKey) throws Exception {
-        Signature rsa = Signature.getInstance("SHA256withRSA");
+        Signature rsa = Signature.getInstance("SHA1withRSA");
         rsa.initSign(privateKey);
         rsa.update(data.getBytes(StandardCharsets.UTF_8));
-        return Base64.getEncoder().encodeToString(rsa.sign());
+        return mimeBase64UrlSafe(rsa.sign());
     }
 }
 


### PR DESCRIPTION
# ☝️Issue Number

- # 49

##  📌 개요

- 이메일 인증 비번 변경 api의 경우 로그아웃 상태임을 상정하여 요청 dto에 이메일을 받는 방식으로 수정
- cloudFront 전송 시 공식문서에 맞게 url 에 담길 값 치환 메서드 추가

- fix : 갑자기 쿠키생성에 실패하는 오류 발생
이유는 알고보니, window 환경에서는 yml파일에서 setx 시 1024단위로 잘라서 저장하여 발생한 것으로 확인.
ec2는 리눅스 기반이므로 그냥 무시하기로 했음
저번에는 왜 됐었는지는 알 길이 없음.

etc : https://learn.microsoft.com/ko-kr/windows-server/administration/windows-commands/setx

https://superuser.com/questions/812754/how-to-recover-from-path-being-truncated-to-1024-characters-by-setx

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점