### PR TITLE
refactor : 통화 참여자 정보 제공 api에서 참여자 이름 정보도 제공

### DIFF
--- a/src/main/java/com/project/syncly/domain/livekit/converter/LiveKitConverter.java
+++ b/src/main/java/com/project/syncly/domain/livekit/converter/LiveKitConverter.java
@@ -9,9 +9,10 @@ public class LiveKitConverter {
     public static String getRoomId(Long workspaceId) {
         return "workspace-" + workspaceId;
     }
-    public static ParticipantInfoDTO toParticipantInfoDTO(String participantId,String profileImageObjectKey, boolean audioSharing, boolean screenSharing) {
+    public static ParticipantInfoDTO toParticipantInfoDTO(String participantId,String participantName ,String profileImageObjectKey, boolean audioSharing, boolean screenSharing) {
         return ParticipantInfoDTO.builder()
                 .participantId(participantId)
+                .participantName(participantName)
                 .profileImageObjectKey(profileImageObjectKey)
                 .audioSharing(audioSharing)
                 .screenSharing(screenSharing)

--- a/src/main/java/com/project/syncly/domain/livekit/dto/ParticipantInfoDTO.java
+++ b/src/main/java/com/project/syncly/domain/livekit/dto/ParticipantInfoDTO.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 @Builder
 public record ParticipantInfoDTO(
         String participantId,
+        String participantName,
         String profileImageObjectKey,
         boolean audioSharing,
         boolean screenSharing

--- a/src/main/java/com/project/syncly/domain/livekit/service/redis/ParticipantStateService.java
+++ b/src/main/java/com/project/syncly/domain/livekit/service/redis/ParticipantStateService.java
@@ -33,6 +33,7 @@ public class ParticipantStateService {
         Member member = memberQueryService.getMemberByIdWithRedis(Long.parseLong(participantId));
         return LiveKitConverter.toParticipantInfoDTO(
                 participantId,
+                member.getName(),
                 member.getProfileImage(),
                 Boolean.parseBoolean(String.valueOf(data.getOrDefault("audioSharing", false))),
                 Boolean.parseBoolean(String.valueOf(data.getOrDefault("screenSharing", false)))


### PR DESCRIPTION
# ☝️Issue Number

- # 49

##  📌 개요

- 통화 참여자 트랙정보 초기 조회시 member의 name도 반환하도록 추가

## 🔁 변경 사항
- livekit 도메인

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점