### PR TITLE
refactor : 통화 참여자 정보 제공 api에서 본인 여부도 제공

### DIFF
--- a/src/main/java/com/project/syncly/domain/livekit/converter/LiveKitConverter.java
+++ b/src/main/java/com/project/syncly/domain/livekit/converter/LiveKitConverter.java
@@ -9,13 +9,14 @@ public class LiveKitConverter {
     public static String getRoomId(Long workspaceId) {
         return "workspace-" + workspaceId;
     }
-    public static ParticipantInfoDTO toParticipantInfoDTO(String participantId,String participantName ,String profileImageObjectKey, boolean audioSharing, boolean screenSharing) {
+    public static ParticipantInfoDTO toParticipantInfoDTO(String participantId,String participantName ,String profileImageObjectKey, boolean audioSharing, boolean screenSharing, boolean isMe) {
         return ParticipantInfoDTO.builder()
                 .participantId(participantId)
                 .participantName(participantName)
                 .profileImageObjectKey(profileImageObjectKey)
                 .audioSharing(audioSharing)
                 .screenSharing(screenSharing)
+                .isMe(isMe)
                 .build();
     }
     public static ParticipantInfoListDTO toParticipantInfoListDTO(String roomId, List<ParticipantInfoDTO> list) {

--- a/src/main/java/com/project/syncly/domain/livekit/dto/ParticipantInfoDTO.java
+++ b/src/main/java/com/project/syncly/domain/livekit/dto/ParticipantInfoDTO.java
@@ -9,6 +9,7 @@ public record ParticipantInfoDTO(
         String participantName,
         String profileImageObjectKey,
         boolean audioSharing,
-        boolean screenSharing
+        boolean screenSharing,
+        boolean isMe
 ) {}
 

--- a/src/main/java/com/project/syncly/domain/livekit/service/redis/ParticipantStateService.java
+++ b/src/main/java/com/project/syncly/domain/livekit/service/redis/ParticipantStateService.java
@@ -23,7 +23,7 @@ public class ParticipantStateService {
 
     private static final Duration TTL = Duration.ofMinutes(60); // 1시간
 
-    public ParticipantInfoDTO getParticipantInfo(String roomId, String participantId) {
+    public ParticipantInfoDTO getParticipantInfo(String roomId, String participantId, Long requesterId) {
         String key = RedisKeyPrefix.CALL_PARTICIPANT.format(roomId, participantId);
         Map<String, Object> data = redisStorage.getHash(key);
 
@@ -36,7 +36,8 @@ public class ParticipantStateService {
                 member.getName(),
                 member.getProfileImage(),
                 Boolean.parseBoolean(String.valueOf(data.getOrDefault("audioSharing", false))),
-                Boolean.parseBoolean(String.valueOf(data.getOrDefault("screenSharing", false)))
+                Boolean.parseBoolean(String.valueOf(data.getOrDefault("screenSharing", false))),
+                member.getId().equals(requesterId)
         );
     }
 

--- a/src/main/java/com/project/syncly/domain/livekit/service/redis/RoomStateService.java
+++ b/src/main/java/com/project/syncly/domain/livekit/service/redis/RoomStateService.java
@@ -49,8 +49,8 @@ public class RoomStateService {
         roomExpirationProducer.deleteRoomExpiration(roomId);
     }
 
-    public ParticipantInfoListDTO getParticipantInfoList(Long workspaceId, Long memberId) {
-        if (!liveKitTokenService.isMemberIncludeWorkspace(memberId, workspaceId)) {
+    public ParticipantInfoListDTO getParticipantInfoList(Long workspaceId, Long requesterId) {
+        if (!liveKitTokenService.isMemberIncludeWorkspace(requesterId, workspaceId)) {
             throw new LiveKitException(LiveKitErrorCode.MEMBER_NOT_INCLUDE_WORKSPACE);
         }
         String roomId = LiveKitConverter.getRoomId(workspaceId);
@@ -62,7 +62,7 @@ public class RoomStateService {
         }
 
         List<ParticipantInfoDTO> list = participantIds.stream()
-                .map(id -> participantStateService.getParticipantInfo(roomId, id))
+                .map(participantId -> participantStateService.getParticipantInfo(roomId, participantId, requesterId))
                 .filter(Objects::nonNull)
                 .toList();
 

--- a/src/main/java/com/project/syncly/global/jwt/JwtFilter.java
+++ b/src/main/java/com/project/syncly/global/jwt/JwtFilter.java
@@ -31,7 +31,7 @@ public class JwtFilter extends OncePerRequestFilter {
     );
 
     @Override
-    protected boolean shouldNotFilter(HttpServletRequest req) {
+    protected boolean shouldNotFilter(HttpServletRequest req) {//사실 정상적이라면 corsFilter 단에서 프리플라이트는 반환해야하므로 shouldNotFilter 할 이유가 없다.
         if ("OPTIONS".equalsIgnoreCase(req.getMethod())) return true;
         return skipMatcher.matches(req);
     }

--- a/src/main/java/com/project/syncly/global/reissueFilter/CsrfFilter.java
+++ b/src/main/java/com/project/syncly/global/reissueFilter/CsrfFilter.java
@@ -52,7 +52,7 @@ public class CsrfFilter extends OncePerRequestFilter {
                 ||req.getRequestURI().startsWith("/api/auth/logout"))) return true;
 
         final String method  = req.getMethod();
-        // 프리플라이트/안전메서드 스킵
+        // 프리플라이트/안전메서드 스킵 /사실 정상적이라면 corsFilter 단에서 프리플라이트는 반환하므로 shouldNotFilter 할 이유가 없다.
         if ("OPTIONS".equalsIgnoreCase(method) || "GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method)) {
             return true;
         }


### PR DESCRIPTION
# ☝️Issue Number

- #49 

##  📌 개요

- 통화 참여자 정보 제공 api에서 본인 여부도 확인하고 싶다는 요구에 따라서, 응답 dto에 본인 확인 컬럼 추가

## 🔁 변경 사항
- livekit 도메인
- jwtFilter, csrfFilter에 주석 추가
## 📸 스크린샷

## 👀 기타 더 이야기해볼 점