### PR TITLE
✨ feat: 채팅기능 개발 #48

### DIFF
--- a/src/main/java/com/project/syncly/domain/chat/controller/ChatHttpController.java
+++ b/src/main/java/com/project/syncly/domain/chat/controller/ChatHttpController.java
@@ -1,4 +1,80 @@
 package com.project.syncly.domain.chat.controller;
 
+import com.project.syncly.domain.chat.dto.ChatHttpResponseDto;
+import com.project.syncly.domain.chat.service.ChatHttpServiceImpl;
+import com.project.syncly.global.apiPayload.CustomResponse;
+import com.project.syncly.global.jwt.PrincipalDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/workspaces")
+@Tag(name = "Chat 관련 API (HTTP 조회 API, WebSocket은 분리)")
+@Validated
 public class ChatHttpController {
+
+    private final ChatHttpServiceImpl chatHttpService;
+
+
+     //1. 최신 채팅 메시지 조회
+     //ex. GET /api/workspaces/{workspaceId}/messages?limit=50
+    @GetMapping("/{workspaceId}/messages")
+    @Operation(summary = "최신 채팅 메시지 조회 (seq ASC 정렬)")
+    public ResponseEntity<CustomResponse<ChatHttpResponseDto.ChatResponseDto>> getLatestMessages(
+            @PathVariable Long workspaceId,
+            @RequestParam(defaultValue = "50") @Min(1) @Max(200) int limit,
+            @AuthenticationPrincipal PrincipalDetails userDetails
+    ) {
+        Long memberId = Long.valueOf(userDetails.getName());
+
+        ChatHttpResponseDto.ChatResponseDto response =
+                chatHttpService.getLatestPage(workspaceId, memberId, limit);
+
+        return ResponseEntity.ok(CustomResponse.success(HttpStatus.OK, response));
+    }
+
+     //2. 과거 메시지 더보기 (무한 스크롤)
+     //ex. GET /api/workspaces/{workspaceId}/messages/before?beforeSeq=123&limit=50
+    @GetMapping("/{workspaceId}/messages/before")
+    @Operation(summary = "과거 메시지 더보기 (무한 스크롤, seq ASC 정렬)")
+    public ResponseEntity<CustomResponse<ChatHttpResponseDto.ChatResponseDto>> getMessagesBefore(
+            @PathVariable Long workspaceId,
+            @RequestParam Long beforeSeq,
+            @RequestParam(defaultValue = "50") @Min(1) @Max(200) int limit,
+            @AuthenticationPrincipal PrincipalDetails userDetails
+    ) {
+        Long memberId = Long.valueOf(userDetails.getName());
+
+        ChatHttpResponseDto.ChatResponseDto response =
+                chatHttpService.getMessagesBefore(workspaceId, memberId, beforeSeq, limit);
+
+        return ResponseEntity.ok(CustomResponse.success(HttpStatus.OK, response));
+    }
+
+     // 3. 끊김 보정 (재연결 델타)
+     //ex. GET /api/workspaces/{workspaceId}/messages/after?afterSeq=10100&limit=200
+    @GetMapping("/{workspaceId}/messages/after")
+    @Operation(summary = "끊김 보정 (afterSeq 이후 메시지 조회, seq ASC 정렬)")
+    public ResponseEntity<CustomResponse<ChatHttpResponseDto.ChatResponseDto>> getMessagesAfter(
+            @PathVariable Long workspaceId,
+            @RequestParam Long afterSeq,
+            @RequestParam(defaultValue = "200") @Min(1) @Max(500) int limit,
+            @AuthenticationPrincipal PrincipalDetails userDetails
+    ) {
+        Long memberId = Long.valueOf(userDetails.getName());
+
+        ChatHttpResponseDto.ChatResponseDto response =
+                chatHttpService.getMessagesAfter(workspaceId, memberId, afterSeq, limit);
+
+        return ResponseEntity.ok(CustomResponse.success(HttpStatus.OK, response));
+    }
 }

--- a/src/main/java/com/project/syncly/domain/chat/controller/ChatHttpController.java
+++ b/src/main/java/com/project/syncly/domain/chat/controller/ChatHttpController.java
@@ -1,0 +1,4 @@
+package com.project.syncly.domain.chat.controller;
+
+public class ChatHttpController {
+}

--- a/src/main/java/com/project/syncly/domain/chat/controller/ChatWebSocketController.java
+++ b/src/main/java/com/project/syncly/domain/chat/controller/ChatWebSocketController.java
@@ -1,0 +1,36 @@
+package com.project.syncly.domain.chat.controller;
+
+import com.project.syncly.domain.chat.dto.ChatWebSocketRequestDto;
+import com.project.syncly.domain.chat.dto.ChatWebSocketResponseDto;
+import com.project.syncly.domain.chat.service.ChatWebSocketServiceImpl;
+import com.project.syncly.domain.url.dto.UrlWebSocketRequestDto;
+import com.project.syncly.domain.url.dto.UrlWebSocketResponseDto;
+import com.project.syncly.global.apiPayload.CustomResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor
+public class ChatWebSocketController {
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ChatWebSocketServiceImpl chatWebSocketService;
+
+    //채팅 메세지 전송 API
+    @MessageMapping("/chat.{workspaceId}.send")
+    public void sendMessage(@DestinationVariable Long workspaceId,
+                            ChatWebSocketRequestDto.CreateChatRequestDto request,
+                            Principal principal) {
+        String userEmail = principal.getName();
+
+        ChatWebSocketResponseDto.ChatResponseDto response = chatWebSocketService.sendMessage(workspaceId, userEmail, request);
+
+        // "/topic/chat.{workspaceID}"를 구독한 실시간 메시지 보내기
+        String destination = "/topic/chat." + workspaceId;
+        messagingTemplate.convertAndSend(destination, CustomResponse.success(response));
+    }
+}

--- a/src/main/java/com/project/syncly/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/com/project/syncly/domain/chat/converter/ChatConverter.java
@@ -1,9 +1,12 @@
 package com.project.syncly.domain.chat.converter;
 
+import com.project.syncly.domain.chat.dto.ChatHttpResponseDto;
 import com.project.syncly.domain.chat.dto.ChatWebSocketResponseDto;
 import com.project.syncly.domain.chat.entity.ChatMessage;
 import com.project.syncly.domain.workspace.entity.Workspace;
 import com.project.syncly.domain.workspaceMember.entity.WorkspaceMember;
+
+import java.util.List;
 
 
 public class ChatConverter {
@@ -27,6 +30,21 @@ public class ChatConverter {
                 .seq(chatMessage.getSeq())
                 .content(chatMessage.getContent())
                 .createdAt(chatMessage.getCreatedAt())
+                .build();
+    }
+
+     // 여러 ChatMessage 엔티티를 Response DTO 리스트로 변환
+    public static List<ChatWebSocketResponseDto.ChatResponseDto> toChatMessageResponseList(List<ChatMessage> messages) {
+        return messages.stream()
+                .map(ChatConverter::toChatMessageResponse)
+                .toList();
+    }
+
+    public static ChatHttpResponseDto.ChatResponseDto toChatResponseDto(List<ChatMessage> messages, Long nextBeforeSeq, Long latestSeq) {
+        return ChatHttpResponseDto.ChatResponseDto.builder()
+                .items(toChatMessageResponseList(messages))
+                .nextBeforeSeq(nextBeforeSeq)
+                .latestSeq(latestSeq)
                 .build();
     }
 }

--- a/src/main/java/com/project/syncly/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/com/project/syncly/domain/chat/converter/ChatConverter.java
@@ -1,0 +1,32 @@
+package com.project.syncly.domain.chat.converter;
+
+import com.project.syncly.domain.chat.dto.ChatWebSocketResponseDto;
+import com.project.syncly.domain.chat.entity.ChatMessage;
+import com.project.syncly.domain.workspace.entity.Workspace;
+import com.project.syncly.domain.workspaceMember.entity.WorkspaceMember;
+
+
+public class ChatConverter {
+
+    public static ChatMessage toChatMessage(Workspace workspace, WorkspaceMember sender, String msgId, Long seq, String content) {
+        return ChatMessage.builder()
+                .workspace(workspace)
+                .sender(sender)
+                .msgId(msgId)
+                .seq(seq)
+                .content(content)
+                .build();
+    }
+
+    public static ChatWebSocketResponseDto.ChatResponseDto toChatMessageResponse(ChatMessage chatMessage) {
+        return ChatWebSocketResponseDto.ChatResponseDto.builder()
+                .id(chatMessage.getId())
+                .workspaceId(chatMessage.getWorkspace().getId())
+                .senderId(chatMessage.getSender().getId())
+                .msgId(chatMessage.getMsgId())
+                .seq(chatMessage.getSeq())
+                .content(chatMessage.getContent())
+                .createdAt(chatMessage.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/project/syncly/domain/chat/dto/ChatHttpResponseDto.java
+++ b/src/main/java/com/project/syncly/domain/chat/dto/ChatHttpResponseDto.java
@@ -1,0 +1,22 @@
+package com.project.syncly.domain.chat.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.List;
+
+public class ChatHttpResponseDto {
+    @Builder
+    @Schema(description = "HTTP 메시지 페이지 조회 응답 DTO")
+    public record ChatResponseDto(
+            @Schema(description = "메시지 리스트")
+            List<ChatWebSocketResponseDto> items, // 재사용
+
+            @Schema(description = "다음 페이지 조회용 beforeSeq (null이면 더 없음)")
+            Long nextBeforeSeq,
+
+            @Schema(description = "서버 기준 최신 seq")
+            Long latestSeq
+    ) {
+    }
+}

--- a/src/main/java/com/project/syncly/domain/chat/dto/ChatHttpResponseDto.java
+++ b/src/main/java/com/project/syncly/domain/chat/dto/ChatHttpResponseDto.java
@@ -10,7 +10,7 @@ public class ChatHttpResponseDto {
     @Schema(description = "HTTP 메시지 페이지 조회 응답 DTO")
     public record ChatResponseDto(
             @Schema(description = "메시지 리스트")
-            List<ChatWebSocketResponseDto> items, // 재사용
+            List<ChatWebSocketResponseDto.ChatResponseDto> items, // 재사용
 
             @Schema(description = "다음 페이지 조회용 beforeSeq (null이면 더 없음)")
             Long nextBeforeSeq,

--- a/src/main/java/com/project/syncly/domain/chat/dto/ChatWebSocketRequestDto.java
+++ b/src/main/java/com/project/syncly/domain/chat/dto/ChatWebSocketRequestDto.java
@@ -1,0 +1,17 @@
+package com.project.syncly.domain.chat.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+public class ChatWebSocketRequestDto {
+    @Builder
+    @Schema(description = "채팅 WebSocket 전송 요청 DTO")
+    public record CreateChatRequestDto(
+            @Schema(description = "클라이언트에서 생성한 메시지 고유 ID(UUID)", example = "550e8400-e29b-41d4-a716-446655440000")
+            String msgId,
+
+            @Schema(description = "메시지 본문", example = "안녕하세요!")
+            String content
+    ) {
+    }
+}

--- a/src/main/java/com/project/syncly/domain/chat/dto/ChatWebSocketResponseDto.java
+++ b/src/main/java/com/project/syncly/domain/chat/dto/ChatWebSocketResponseDto.java
@@ -1,0 +1,35 @@
+package com.project.syncly.domain.chat.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+public class ChatWebSocketResponseDto {
+    @Builder
+    @Schema(description = "채팅 WebSocket 응답 DTO")
+    public record ChatResponseDto(
+            @Schema(description = "메시지 ID", example = "12345")
+            Long id,
+
+            @Schema(description = "워크스페이스 ID", example = "77")
+            Long workspaceId,
+
+            @Schema(description = "보낸 멤버 ID", example = "1001")
+            Long senderId,
+
+            @Schema(description = "클라이언트에서 보낸 msgId(UUID)", example = "550e8400-e29b-41d4-a716-446655440000")
+            String msgId,
+
+            @Schema(description = "워크스페이스 내 순차 증가 seq", example = "101")
+            Long seq,
+
+            @Schema(description = "메시지 본문", example = "안녕하세요!")
+            String content,
+
+            @Schema(description = "작성 시간")
+            LocalDateTime createdAt
+    ) {
+    }
+
+}

--- a/src/main/java/com/project/syncly/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/project/syncly/domain/chat/entity/ChatMessage.java
@@ -1,0 +1,47 @@
+package com.project.syncly.domain.chat.entity;
+
+import com.project.syncly.domain.workspace.entity.Workspace;
+import com.project.syncly.domain.workspaceMember.entity.WorkspaceMember;
+import com.project.syncly.global.entity.BaseCreatedEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "chat_message",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_ws_msgid", columnNames = {"workspace_id","msg_id"}),
+                @UniqueConstraint(name = "uq_ws_seq",   columnNames = {"workspace_id","seq"})
+        },
+        indexes = {
+                @Index(name = "idx_ws_created", columnList = "workspace_id, created_at")
+        })
+public class ChatMessage extends BaseCreatedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "workspace_id", nullable = false)
+    private Workspace workspace;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private WorkspaceMember sender;
+
+    @Column(name = "msg_id", nullable = false, length = 36)
+    private String msgId;
+
+    @Column(name = "seq", nullable = false)
+    private Long seq;
+
+    @Lob
+    @Column(name = "chat_message", nullable = false, columnDefinition = "TEXT")
+    private String content;
+}
+

--- a/src/main/java/com/project/syncly/domain/chat/entity/WorkspaceSeq.java
+++ b/src/main/java/com/project/syncly/domain/chat/entity/WorkspaceSeq.java
@@ -1,0 +1,20 @@
+package com.project.syncly.domain.chat.entity;
+
+import com.project.syncly.domain.workspace.entity.Workspace;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "workspace_seq")
+public class WorkspaceSeq {
+    @Id
+    @Column(name = "workspace_id")
+    private Long workspaceId;
+
+    @Column(name = "current_seq", nullable = false)
+    private Long currentSeq;
+}

--- a/src/main/java/com/project/syncly/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/project/syncly/domain/chat/exception/ChatErrorCode.java
@@ -9,8 +9,22 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ChatErrorCode implements BaseErrorCode {
 
-    //채팅 관련 에러
-    WORKSPACE_NOT_FOUND(HttpStatus.NOT_FOUND, "Workspace404_0", "워크스페이스가 존재하지 않습니다."); //예시
+    // 사용자 관련 에러
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "Chat404_0", "존재하지 않는 유저입니다."),
+
+    // 워크스페이스 관련
+    WORKSPACE_NOT_FOUND(HttpStatus.NOT_FOUND, "Chat404_1", "워크스페이스가 존재하지 않습니다."),
+    NOT_WORKSPACE_MEMBER(HttpStatus.FORBIDDEN, "Chat403_0", "워크스페이스 멤버가 아닙니다."),
+    NOT_TEAM_WORKSPACE(HttpStatus.BAD_REQUEST, "Chat400_0", "팀 워크스페이스가 아닙니다."),
+
+    // 메시지 관련
+    MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "Chat404_2", "채팅 메시지를 찾을 수 없습니다."),
+    DUPLICATE_MESSAGE(HttpStatus.CONFLICT, "Chat409_0", "이미 존재하는 메시지입니다."),
+    INVALID_SEQ_RANGE(HttpStatus.BAD_REQUEST, "Chat400_1", "유효하지 않은 seq 범위입니다."),
+
+    // 연결/상태 관련
+    USER_NOT_CONNECTED(HttpStatus.BAD_REQUEST, "Chat400_2", "유저가 WebSocket에 연결되지 않았습니다."),
+    SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Chat500_0", "메시지 전송에 실패했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/project/syncly/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/project/syncly/domain/chat/exception/ChatErrorCode.java
@@ -1,0 +1,18 @@
+package com.project.syncly.domain.chat.exception;
+
+import com.project.syncly.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ChatErrorCode implements BaseErrorCode {
+
+    //채팅 관련 에러
+    WORKSPACE_NOT_FOUND(HttpStatus.NOT_FOUND, "Workspace404_0", "워크스페이스가 존재하지 않습니다."); //예시
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/project/syncly/domain/chat/exception/ChatException.java
+++ b/src/main/java/com/project/syncly/domain/chat/exception/ChatException.java
@@ -1,0 +1,9 @@
+package com.project.syncly.domain.chat.exception;
+
+import com.project.syncly.global.apiPayload.exception.CustomException;
+
+public class ChatException extends CustomException {
+    public ChatException(ChatErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/project/syncly/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/project/syncly/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,48 @@
+package com.project.syncly.domain.chat.repository;
+
+import com.project.syncly.domain.chat.entity.ChatMessage;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    Optional<ChatMessage> findByWorkspaceIdAndMsgId(Long workspaceId, String msgId);
+
+    Optional<ChatMessage> findByWorkspaceIdAndSeq(Long workspaceId, Long seq);
+
+    // 최신 N개 (내부적으로 DESC로 가져와서 서비스에서 ASC로 뒤집어도 됨)
+    @Query("""
+    SELECT m FROM ChatMessage m
+    WHERE m.workspace.id = :ws
+    ORDER BY m.seq DESC
+    """)
+    List<ChatMessage> findLatest(@Param("ws") Long wsId, Pageable pageable);
+
+    // 과거 더보기
+    @Query("""
+    SELECT m FROM ChatMessage m
+    WHERE m.workspace.id = :ws AND m.seq < :beforeSeq
+    ORDER BY m.seq DESC
+    """)
+    List<ChatMessage> findBefore(@Param("ws") Long wsId, @Param("beforeSeq") Long beforeSeq, Pageable pageable);
+
+    // 끊김 보정(델타)
+    @Query("""
+    SELECT m FROM ChatMessage m
+    WHERE m.workspace.id = :ws AND m.seq > :afterSeq
+    ORDER BY m.seq ASC
+    """)
+    List<ChatMessage> findAfter(@Param("ws") Long wsId, @Param("afterSeq") Long afterSeq, Pageable pageable);
+
+    @Query("SELECT COALESCE(MAX(m.seq),0) FROM ChatMessage m WHERE m.workspace.id=:ws")
+    Long findLatestSeq(@Param("ws") Long wsId);
+}
+
+

--- a/src/main/java/com/project/syncly/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/project/syncly/domain/chat/repository/ChatMessageRepository.java
@@ -17,7 +17,7 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 
     Optional<ChatMessage> findByWorkspaceIdAndSeq(Long workspaceId, Long seq);
 
-    // 최신 N개 (내부적으로 DESC로 가져와서 서비스에서 ASC로 뒤집어도 됨)
+    // 최신 N개
     @Query("""
     SELECT m FROM ChatMessage m
     WHERE m.workspace.id = :ws

--- a/src/main/java/com/project/syncly/domain/chat/repository/WorkspaceSeqRepository.java
+++ b/src/main/java/com/project/syncly/domain/chat/repository/WorkspaceSeqRepository.java
@@ -1,0 +1,26 @@
+package com.project.syncly.domain.chat.repository;
+
+import com.project.syncly.domain.chat.entity.WorkspaceSeq;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface WorkspaceSeqRepository extends JpaRepository<WorkspaceSeq, Long> {
+    // MySQL: 증가 + 증가값을 LAST_INSERT_ID()로 설정
+    @Modifying
+    @Query(value = """
+      UPDATE workspace_seq
+      SET current_seq = LAST_INSERT_ID(current_seq + 1)
+      WHERE workspace_id = :wsId
+      """, nativeQuery = true)
+    int bumpAndSetLastInsertId(@Param("wsId") long wsId);
+
+    @Query(value = "SELECT LAST_INSERT_ID()", nativeQuery = true)
+    long fetchLastInsertId();
+}
+
+

--- a/src/main/java/com/project/syncly/domain/chat/service/ChatHttpService.java
+++ b/src/main/java/com/project/syncly/domain/chat/service/ChatHttpService.java
@@ -1,0 +1,13 @@
+package com.project.syncly.domain.chat.service;
+
+
+import com.project.syncly.domain.chat.dto.ChatHttpResponseDto;
+
+public interface ChatHttpService {
+
+    ChatHttpResponseDto.ChatResponseDto getLatestPage(Long workspaceId, Long memberId, int limit);
+
+    ChatHttpResponseDto.ChatResponseDto getMessagesBefore(Long workspaceId, Long memberId, Long beforeSeq, int limit);
+
+    ChatHttpResponseDto.ChatResponseDto getMessagesAfter(Long workspaceId, Long memberId, Long afterSeq, int limit);
+}

--- a/src/main/java/com/project/syncly/domain/chat/service/ChatHttpServiceImpl.java
+++ b/src/main/java/com/project/syncly/domain/chat/service/ChatHttpServiceImpl.java
@@ -1,0 +1,120 @@
+package com.project.syncly.domain.chat.service;
+
+import com.project.syncly.domain.chat.dto.ChatHttpResponseDto;
+import com.project.syncly.domain.chat.entity.ChatMessage;
+import com.project.syncly.domain.chat.exception.ChatErrorCode;
+import com.project.syncly.domain.chat.repository.ChatMessageRepository;
+import com.project.syncly.domain.chat.converter.ChatConverter;
+import com.project.syncly.domain.member.entity.Member;
+import com.project.syncly.domain.member.repository.MemberRepository;
+import com.project.syncly.domain.workspace.entity.Workspace;
+import com.project.syncly.domain.workspace.entity.enums.WorkspaceType;
+import com.project.syncly.domain.workspace.exception.WorkspaceErrorCode;
+import com.project.syncly.domain.workspace.repository.WorkspaceRepository;
+import com.project.syncly.domain.workspaceMember.repository.WorkspaceMemberRepository;
+import com.project.syncly.global.apiPayload.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatHttpServiceImpl implements ChatHttpService {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final WorkspaceRepository workspaceRepository;
+    private final WorkspaceMemberRepository workspaceMemberRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public ChatHttpResponseDto.ChatResponseDto getLatestPage(Long workspaceId, Long memberId, int limit) {
+        // 멤버 존재 확인
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ChatErrorCode.MEMBER_NOT_FOUND));
+
+        // 워크스페이스 존재 여부 확인
+        Workspace workspace = workspaceRepository.findById(workspaceId)
+                .orElseThrow(() -> new CustomException(ChatErrorCode.WORKSPACE_NOT_FOUND));
+
+        // 워크스페이스 멤버 여부 확인
+        workspaceMemberRepository.findByWorkspaceIdAndMemberId(workspaceId, member.getId())
+                .orElseThrow(() -> new CustomException(ChatErrorCode.NOT_WORKSPACE_MEMBER));
+
+        // 팀 워크스페이스인지 확인
+        if (workspace.getWorkspaceType() != WorkspaceType.TEAM) {
+            throw new CustomException(ChatErrorCode.NOT_TEAM_WORKSPACE);
+        }
+
+        // 최신 limit개 메시지
+        List<ChatMessage> messages = chatMessageRepository.findLatest(workspaceId, PageRequest.of(0, limit));
+        Collections.reverse(messages);
+
+        //불러온 메세지 중 가장 예전 메시지의 seq
+        Long nextBeforeSeq = messages.isEmpty() ? null : messages.get(0).getSeq();
+
+        //가장 최신의 메세지 seq
+        Long latestSeq = chatMessageRepository.findLatestSeq(workspaceId);
+
+        return ChatConverter.toChatResponseDto(messages, nextBeforeSeq, latestSeq);
+    }
+
+    @Override
+    public ChatHttpResponseDto.ChatResponseDto getMessagesBefore(Long workspaceId, Long memberId, Long beforeSeq, int limit) {
+        // 멤버 존재 확인
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(WorkspaceErrorCode.MEMBER_NOT_FOUND));
+
+        // 워크스페이스 존재 여부 확인
+        Workspace workspace = workspaceRepository.findById(workspaceId)
+                .orElseThrow(() -> new CustomException(ChatErrorCode.WORKSPACE_NOT_FOUND));
+
+        // 워크스페이스 멤버 여부 확인
+        workspaceMemberRepository.findByWorkspaceIdAndMemberId(workspaceId, member.getId())
+                .orElseThrow(() -> new CustomException(ChatErrorCode.NOT_WORKSPACE_MEMBER));
+
+        // 팀 워크스페이스인지 확인
+        if (workspace.getWorkspaceType() != WorkspaceType.TEAM) {
+            throw new CustomException(ChatErrorCode.NOT_TEAM_WORKSPACE);
+        }
+
+        List<ChatMessage> messages = chatMessageRepository.findBefore(workspaceId, beforeSeq, PageRequest.of(0, limit));
+        Collections.reverse(messages);
+
+        Long nextBeforeSeq = messages.isEmpty() ? null : messages.get(0).getSeq();
+        Long latestSeq = chatMessageRepository.findLatestSeq(workspaceId);
+
+        return ChatConverter.toChatResponseDto(messages, nextBeforeSeq, latestSeq);
+    }
+
+    @Override
+    public ChatHttpResponseDto.ChatResponseDto getMessagesAfter(Long workspaceId, Long memberId, Long afterSeq, int limit) {
+        // 멤버 존재 확인
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(WorkspaceErrorCode.MEMBER_NOT_FOUND));
+
+        // 워크스페이스 존재 여부 확인
+        Workspace workspace = workspaceRepository.findById(workspaceId)
+                .orElseThrow(() -> new CustomException(ChatErrorCode.WORKSPACE_NOT_FOUND));
+
+        // 워크스페이스 멤버 여부 확인
+        workspaceMemberRepository.findByWorkspaceIdAndMemberId(workspaceId, member.getId())
+                .orElseThrow(() -> new CustomException(ChatErrorCode.NOT_WORKSPACE_MEMBER));
+
+        // 팀 워크스페이스인지 확인
+        if (workspace.getWorkspaceType() != WorkspaceType.TEAM) {
+            throw new CustomException(ChatErrorCode.NOT_TEAM_WORKSPACE);
+        }
+
+        List<ChatMessage> messages = chatMessageRepository.findAfter(workspaceId, afterSeq, PageRequest.of(0, limit));
+
+        Long nextBeforeSeq = messages.isEmpty() ? null : messages.get(0).getSeq();
+        Long latestSeq = chatMessageRepository.findLatestSeq(workspaceId);
+
+        return ChatConverter.toChatResponseDto(messages, nextBeforeSeq, latestSeq);
+    }
+}

--- a/src/main/java/com/project/syncly/domain/chat/service/ChatWebSocketService.java
+++ b/src/main/java/com/project/syncly/domain/chat/service/ChatWebSocketService.java
@@ -1,0 +1,10 @@
+package com.project.syncly.domain.chat.service;
+
+import com.project.syncly.domain.chat.dto.ChatWebSocketRequestDto;
+import com.project.syncly.domain.chat.dto.ChatWebSocketResponseDto;
+import com.project.syncly.domain.url.dto.UrlWebSocketRequestDto;
+import com.project.syncly.domain.url.dto.UrlWebSocketResponseDto;
+
+public interface ChatWebSocketService {
+    public ChatWebSocketResponseDto.ChatResponseDto sendMessage(Long workspaceId, String userEmail, ChatWebSocketRequestDto.CreateChatRequestDto request);
+}

--- a/src/main/java/com/project/syncly/domain/chat/service/ChatWebSocketServiceImpl.java
+++ b/src/main/java/com/project/syncly/domain/chat/service/ChatWebSocketServiceImpl.java
@@ -1,0 +1,83 @@
+package com.project.syncly.domain.chat.service;
+
+import com.project.syncly.domain.chat.converter.ChatConverter;
+import com.project.syncly.domain.chat.dto.ChatWebSocketRequestDto;
+import com.project.syncly.domain.chat.dto.ChatWebSocketResponseDto;
+import com.project.syncly.domain.chat.entity.ChatMessage;
+import com.project.syncly.domain.chat.repository.ChatMessageRepository;
+import com.project.syncly.domain.chat.repository.WorkspaceSeqRepository;
+import com.project.syncly.domain.member.entity.Member;
+import com.project.syncly.domain.member.exception.MemberErrorCode;
+import com.project.syncly.domain.member.exception.MemberException;
+import com.project.syncly.domain.member.repository.MemberRepository;
+import com.project.syncly.domain.url.converter.UrlTabConverter;
+import com.project.syncly.domain.url.dto.UrlWebSocketRequestDto;
+import com.project.syncly.domain.url.dto.UrlWebSocketResponseDto;
+import com.project.syncly.domain.url.entity.UrlTab;
+import com.project.syncly.domain.url.exception.UrlErrorCode;
+import com.project.syncly.domain.url.exception.UrlException;
+import com.project.syncly.domain.workspace.entity.Workspace;
+import com.project.syncly.domain.workspace.entity.enums.WorkspaceType;
+import com.project.syncly.domain.workspace.exception.WorkspaceErrorCode;
+import com.project.syncly.domain.workspace.repository.WorkspaceRepository;
+import com.project.syncly.domain.workspaceMember.entity.WorkspaceMember;
+import com.project.syncly.domain.workspaceMember.repository.WorkspaceMemberRepository;
+import com.project.syncly.global.apiPayload.exception.CustomException;
+import com.project.syncly.global.redis.enums.RedisKeyPrefix;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatWebSocketServiceImpl implements ChatWebSocketService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final WorkspaceMemberRepository workspaceMemberRepository;
+    private final MemberRepository memberRepository;
+    private final WorkspaceRepository workspaceRepository;
+    private final ChatMessageRepository chatRepository;
+    private final SeqAllocator seqAllocator;
+
+
+    @Override
+    public ChatWebSocketResponseDto.ChatResponseDto sendMessage(Long workspaceId, String userEmail, ChatWebSocketRequestDto.CreateChatRequestDto request) {
+        //연결 확인
+        boolean isConnected = Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(RedisKeyPrefix.WS_ONLINE_USERS.get(), userEmail));
+        if (!isConnected) {
+            throw new UrlException(UrlErrorCode.USER_NOT_CONNECTED);
+        }
+
+        // 이메일로 Member 조회
+        Member member = memberRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        Long memberId = member.getId(); // 실제 ID 추출
+
+        // 워크스페이스 조회
+        Workspace workspace = workspaceRepository.findById(workspaceId)
+                .orElseThrow(() -> new CustomException(WorkspaceErrorCode.WORKSPACE_NOT_FOUND));
+
+        // 팀 워크스페이스인지 확인
+        if (workspace.getWorkspaceType() != WorkspaceType.TEAM) {
+            throw new CustomException(WorkspaceErrorCode.NOT_TEAM_WORKSPACE);
+        }
+
+        // 워크스페이스 멤버 조회
+        WorkspaceMember sender = workspaceMemberRepository.findByWorkspaceIdAndMemberId(workspaceId, memberId)
+                .orElseThrow(() -> new CustomException(WorkspaceErrorCode.NOT_WORKSPACE_MEMBER));
+
+        // 멱등 처리 - 이미 존재하면 그대로 반환
+        var dup = chatRepository.findByWorkspaceIdAndMsgId(workspaceId, request.msgId());
+        if (dup.isPresent()) return ChatConverter.toChatMessageResponse(dup.get());
+
+        // seq 배정
+        long seq = seqAllocator.nextSeq(workspaceId);
+
+        // 저장
+        ChatMessage chatMessage = ChatConverter.toChatMessage(workspace, sender, request.msgId(), seq, request.content());
+        chatRepository.save(chatMessage);
+
+        return ChatConverter.toChatMessageResponse(chatMessage);
+    }
+}

--- a/src/main/java/com/project/syncly/domain/chat/service/ChatWebSocketServiceImpl.java
+++ b/src/main/java/com/project/syncly/domain/chat/service/ChatWebSocketServiceImpl.java
@@ -67,7 +67,7 @@ public class ChatWebSocketServiceImpl implements ChatWebSocketService {
         WorkspaceMember sender = workspaceMemberRepository.findByWorkspaceIdAndMemberId(workspaceId, memberId)
                 .orElseThrow(() -> new CustomException(WorkspaceErrorCode.NOT_WORKSPACE_MEMBER));
 
-        // 멱등 처리 - 이미 존재하면 그대로 반환
+        // 멱등 처리 - 이미 존재하면 그대로 반환(네트워크 오류로 인해 같은 메시지가 여러번 재전송 되었을 경우)
         var dup = chatRepository.findByWorkspaceIdAndMsgId(workspaceId, request.msgId());
         if (dup.isPresent()) return ChatConverter.toChatMessageResponse(dup.get());
 

--- a/src/main/java/com/project/syncly/domain/chat/service/SeqAllocator.java
+++ b/src/main/java/com/project/syncly/domain/chat/service/SeqAllocator.java
@@ -1,0 +1,25 @@
+package com.project.syncly.domain.chat.service;
+
+import com.project.syncly.domain.chat.entity.WorkspaceSeq;
+import com.project.syncly.domain.chat.repository.WorkspaceSeqRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class SeqAllocator {
+
+    private final WorkspaceSeqRepository seqRepository;
+
+    @Transactional
+    public long nextSeq(Long workspaceId) {
+        int updated = seqRepository.bumpAndSetLastInsertId(workspaceId);
+        if (updated == 0) {
+            // workspace_seq 행이 없을 때 초기화
+            seqRepository.save(new WorkspaceSeq(workspaceId, 0L));
+            seqRepository.bumpAndSetLastInsertId(workspaceId);
+        }
+        return seqRepository.fetchLastInsertId();
+    }
+}

--- a/src/main/java/com/project/syncly/global/config/WebSocketConfig.java
+++ b/src/main/java/com/project/syncly/global/config/WebSocketConfig.java
@@ -11,6 +11,7 @@ import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
 
 @Configuration
 @EnableWebSocketMessageBroker //STOMP를 활용한 WebSocket 메시징 기능 활성화
@@ -39,4 +40,12 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void configureClientInboundChannel(ChannelRegistration registration) {
         registration.interceptors(stompHandler);
     }
+
+    @Override  //웹소켓 메시징 처리에서 메시지 크기, 버퍼, 전송 시간 제한 같은 전송 계층 옵션 설정
+    public void configureWebSocketTransport(WebSocketTransportRegistration reg) {
+        reg.setMessageSizeLimit(1 * 1024 * 1024)       // 메시지 크기 제한 (바이트)
+                .setSendBufferSizeLimit(10 * 1024 * 1024)   // 세션별 전송 버퍼 제한 (바이트)
+                .setSendTimeLimit(15_000);                  // 메시지 전송 제한 시간 (ms)
+    }
+
 }


### PR DESCRIPTION
# ☝️Issue Number

- #48 

##  📌 개요

- 채팅기능 API 개발 (HTTP API 3개, Websocket 1개)


## 🔁 변경 사항
    - 텍스트 크기 상한 config 설정
    - 테이블 Entity 생성
    - WebSocket(STOMP) 경로 설정 및 전송 웹소켓 API 개발
        - 구독: /topic/chat.{wsId}
        - 발신: /app/chat.{wsId}.send
    - REST 조회 API (커서 기반 무한 스크롤)
        - 최신 채팅 메세지 조회 [GET /api/workspaces/{wsId}/messages?limit=50] / 응답(항상 seq ASC 정렬):
        - 과거 더보기(위로 스크롤) [GET /api/workspaces/{wsId}/messages?beforeSeq=10073&limit=50] / 응답(ASC): items,         - nextBeforeSeq
        - 끊김 보정(재연결 델타) [GET /api/workspaces/{wsId}/messages?afterSeq=10100&limit=200] / 응답(ASC): items, latestSeq



## 📸 스크린샷
<img width="1625" height="561" alt="image" src="https://github.com/user-attachments/assets/f53383aa-9ccc-4050-92fd-37a1ce978530" />
<img width="1902" height="885" alt="image" src="https://github.com/user-attachments/assets/cddfa844-d9c6-4659-b60e-8436078d57ea" />




## 👀 기타 더 이야기해볼 점
etc
Origin 제한 추후 설정 예정
SimpleBroker는 인메모리라 단일 인스턴스,소규모에 적합 -> 추후 다중 인스턴스/수평확장·순서보장 필요하면 외부 STOMP 브로커(RabbitMQ/Artemis)로 전환 계획
최근 N개 메시지는 Redis 캐시에 보관하면 최신 페이지 응답이 매우 빠름 (추후 최적화)