### PR TITLE
✨ feat : 자신의 WorkspaceMemberId 조회 API 추가 구현 #76

### DIFF
--- a/src/main/java/com/project/syncly/domain/chat/controller/ChatHttpController.java
+++ b/src/main/java/com/project/syncly/domain/chat/controller/ChatHttpController.java
@@ -77,4 +77,18 @@ public class ChatHttpController {
 
         return ResponseEntity.ok(CustomResponse.success(HttpStatus.OK, response));
     }
+
+    //4. 자신의 workspaceMemberId 조회 API (채팅에서 본인 메시지 확인용)
+    @GetMapping("/{workspaceId}/me")
+    @Operation(summary = "자신의 workspaceMemberId 조회")
+    public ResponseEntity<CustomResponse<Long>> getMyWorkspaceMemberId(
+            @PathVariable Long workspaceId,
+            @AuthenticationPrincipal PrincipalDetails userDetails
+    ) {
+        Long memberId = Long.valueOf(userDetails.getName());
+
+        Long workspaceMemberId = chatHttpService.getMyWorkspaceMemberId(workspaceId, memberId);
+
+        return ResponseEntity.ok(CustomResponse.success(HttpStatus.OK, workspaceMemberId));
+    }
 }

--- a/src/main/java/com/project/syncly/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/com/project/syncly/domain/chat/converter/ChatConverter.java
@@ -26,6 +26,7 @@ public class ChatConverter {
                 .id(chatMessage.getId())
                 .workspaceId(chatMessage.getWorkspace().getId())
                 .senderId(chatMessage.getSender().getId())
+                .senderName(chatMessage.getSender().getName())
                 .msgId(chatMessage.getMsgId())
                 .seq(chatMessage.getSeq())
                 .content(chatMessage.getContent())

--- a/src/main/java/com/project/syncly/domain/chat/dto/ChatWebSocketResponseDto.java
+++ b/src/main/java/com/project/syncly/domain/chat/dto/ChatWebSocketResponseDto.java
@@ -18,6 +18,12 @@ public class ChatWebSocketResponseDto {
             @Schema(description = "보낸 멤버 ID", example = "1001")
             Long senderId,
 
+            @Schema(description = "보낸 멤버 이름", example = "강바다")
+            String senderName,
+
+            @Schema(description = "자신이 보낸 메시지 여부 확인", example = "true")
+            Boolean isSelf,
+
             @Schema(description = "클라이언트에서 보낸 msgId(UUID)", example = "550e8400-e29b-41d4-a716-446655440000")
             String msgId,
 

--- a/src/main/java/com/project/syncly/domain/chat/service/ChatHttpService.java
+++ b/src/main/java/com/project/syncly/domain/chat/service/ChatHttpService.java
@@ -10,4 +10,8 @@ public interface ChatHttpService {
     ChatHttpResponseDto.ChatResponseDto getMessagesBefore(Long workspaceId, Long memberId, Long beforeSeq, int limit);
 
     ChatHttpResponseDto.ChatResponseDto getMessagesAfter(Long workspaceId, Long memberId, Long afterSeq, int limit);
+
+    Long getMyWorkspaceMemberId(Long workspaceId, Long memberId);
 }
+
+

--- a/src/main/java/com/project/syncly/domain/chat/service/ChatHttpServiceImpl.java
+++ b/src/main/java/com/project/syncly/domain/chat/service/ChatHttpServiceImpl.java
@@ -117,4 +117,21 @@ public class ChatHttpServiceImpl implements ChatHttpService {
 
         return ChatConverter.toChatResponseDto(messages, nextBeforeSeq, latestSeq);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Long getMyWorkspaceMemberId(Long workspaceId, Long memberId) {
+        // 멤버 존재 확인
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ChatErrorCode.MEMBER_NOT_FOUND));
+
+        // 워크스페이스 존재 여부 확인
+        workspaceRepository.findById(workspaceId)
+                .orElseThrow(() -> new CustomException(ChatErrorCode.WORKSPACE_NOT_FOUND));
+
+        // 워크스페이스 멤버 조회
+        return workspaceMemberRepository.findByWorkspaceIdAndMemberId(workspaceId, member.getId())
+                .orElseThrow(() -> new CustomException(ChatErrorCode.NOT_WORKSPACE_MEMBER))
+                .getId();  // PK(workspaceMemberId) 반환
+    }
 }


### PR DESCRIPTION
# ☝️Issue Number

- #76 

##  📌 개요
- 자신의 WorkspaceMemberId 조회 API 추가 구현 (/api/workspaces/{workspaceId}/me)
- 채팅 메시지 수신 응답에 발신자 이름 추가하기


## 🔁 변경 사항
- 자신의 WorkspaceMemberId 조회 API 추가 구현
- 채팅 메시지 수신 응답에 발신자 이름 추가하기

## 📸 스크린샷
<img width="806" height="278" alt="image" src="https://github.com/user-attachments/assets/8340b635-d0d7-4825-b48e-52d5f18f96de" />

Websocket 응답값에 workspaceMemberName 추가
[/topic/chat.3] {"isSuccess":true,"code":"200","message":"OK","result":{"id":36,"workspaceId":3,"senderId":4,"senderName":"강바다","isSelf":null,"msgId":"3c26934f-03df-4235-b9c3-84ee45db4d22","seq":36,"content":"안녕하세요!","createdAt":"2025-09-25T15:15:55.2622454"}}
<img width="728" height="145" alt="image" src="https://github.com/user-attachments/assets/c8dcee3a-2e58-47bd-a7a2-1095e3efb09a" />


## 👀 기타 더 이야기해볼 점