### PR TITLE
✨ feat: 전체적인 파일 api 점검 및 삭제시 복원 api 구현

### DIFF
--- a/src/main/java/com/project/syncly/domain/file/controller/FileController.java
+++ b/src/main/java/com/project/syncly/domain/file/controller/FileController.java
@@ -31,7 +31,32 @@ public class FileController {
     private final FileQueryService fileQueryService;
 
     @PostMapping("/{workspaceId}/files/presigned-url")
-    @Operation(summary = "파일 업로드 Presigned URL 발급", description = "워크스페이스에 파일을 업로드하기 위한 Presigned URL을 발급합니다.")
+    @Operation(
+            summary = "파일 업로드 Presigned URL 발급",
+            description = """
+                    워크스페이스에 파일을 업로드하기 위한 S3 Presigned URL을 발급합니다.
+
+                    **사용 방법:**
+                    1. 이 API로 Presigned URL 발급
+                    2. 발급받은 URL로 S3에 직접 파일 업로드 (PUT 요청)
+                    3. /confirm-upload API로 업로드 완료 확인
+
+                    **중요 사항:**
+                    - **파일명에는 반드시 확장자가 포함되어야 합니다.**
+                    - 예시: "보고서.pdf", "이미지.jpg", "동영상.mp4"
+                    - 확장자 없이 입력하면 오류가 발생합니다.
+
+                    **파일 제한사항:**
+                    - 최대 크기: 200MB (209,715,200 바이트)
+                    - 지원 형식: 이미지(jpg,png,gif,bmp,svg,webp), 동영상(mp4,avi,mkv,mov,wmv,flv,webm), 문서(pdf,doc,docx,xls,xlsx,ppt,pptx,txt)
+
+                    **파일 크기 참고:**
+                    - 1KB = 1,024 바이트
+                    - 1MB = 1,048,576 바이트
+                    - 10MB = 10,485,760 바이트
+                    - 100MB = 104,857,600 바이트
+                    """
+    )
     public ResponseEntity<CustomResponse<FileResponseDto.PresignedUrl>> getFileUploadPresignedUrl(
             @PathVariable Long workspaceId,
             @RequestBody @Valid FileRequestDto.UploadPresignedUrl requestDto,
@@ -46,7 +71,23 @@ public class FileController {
     }
 
     @PostMapping("/{workspaceId}/files/confirm-upload")
-    @Operation(summary = "파일 업로드 완료 확인", description = "Presigned URL로 업로드 완료된 파일을 DB에 저장합니다.")
+    @Operation(
+            summary = "파일 업로드 완료 확인",
+            description = """
+                    Presigned URL로 업로드 완료된 파일을 DB에 저장합니다.
+
+                    **중요 사항:**
+                    - **파일명에는 반드시 확장자가 포함되어야 합니다.**
+                    - Presigned URL 발급 시 사용한 파일명과 동일해야 합니다.
+                    - 예시: "보고서.pdf", "이미지.jpg", "동영상.mp4"
+                    - 확장자 없이 입력하면 오류가 발생합니다.
+
+                    **사용 순서:**
+                    1. Presigned URL 발급 (fileName: "파일.pdf")
+                    2. S3에 파일 업로드
+                    3. 이 API로 업로드 완료 확인 (fileName: "파일.pdf")
+                    """
+    )
     public ResponseEntity<CustomResponse<FileResponseDto.Upload>> confirmFileUpload(
             @PathVariable Long workspaceId,
             @RequestBody @Valid FileRequestDto.ConfirmUpload requestDto,
@@ -74,7 +115,21 @@ public class FileController {
     }
 
     @PatchMapping("/{workspaceId}/files/{fileId}")
-    @Operation(summary = "파일 이름 변경", description = "워크스페이스의 파일 이름을 변경합니다.")
+    @Operation(
+            summary = "파일 이름 변경",
+            description = """
+                    워크스페이스의 파일 이름을 변경합니다.
+
+                    **중요 사항:**
+                    - 파일명에는 **반드시 확장자가 포함**되어야 합니다.
+                    - 예시: "보고서.pdf", "이미지.jpg", "문서.docx"
+                    - 확장자 없이 입력하면 오류가 발생합니다.
+
+                    **참고:**
+                    - 실제 S3 파일은 변경되지 않고, 표시 이름만 변경됩니다.
+                    - 같은 폴더 내에 동일한 이름의 파일이 있으면 오류가 발생합니다.
+                    """
+    )
     public ResponseEntity<CustomResponse<FileResponseDto.Update>> updateFile(
             @PathVariable Long workspaceId,
             @PathVariable Long fileId,

--- a/src/main/java/com/project/syncly/domain/file/converter/FileConverter.java
+++ b/src/main/java/com/project/syncly/domain/file/converter/FileConverter.java
@@ -19,6 +19,7 @@ public class FileConverter {
                 .type(fileType)
                 .objectKey(objectKey)
                 .size(multipartFile.getSize())
+                .fileUrl(null)
                 .build();
     }
 
@@ -32,6 +33,7 @@ public class FileConverter {
                 .type(originalFile.getType())
                 .objectKey(originalFile.getObjectKey())
                 .size(originalFile.getSize())
+                .fileUrl(originalFile.getFileUrl())
                 .deletedAt(originalFile.getDeletedAt())
                 .build();
     }
@@ -46,6 +48,7 @@ public class FileConverter {
                 .type(originalFile.getType())
                 .objectKey(originalFile.getObjectKey())
                 .size(originalFile.getSize())
+                .fileUrl(originalFile.getFileUrl())
                 .deletedAt(LocalDateTime.now())
                 .build();
     }
@@ -60,6 +63,7 @@ public class FileConverter {
                 .type(originalFile.getType())
                 .objectKey(originalFile.getObjectKey())
                 .size(originalFile.getSize())
+                .fileUrl(originalFile.getFileUrl())
                 .deletedAt(null)
                 .build();
     }
@@ -74,6 +78,22 @@ public class FileConverter {
                 .type(originalFile.getType())
                 .objectKey(originalFile.getObjectKey())
                 .size(originalFile.getSize())
+                .fileUrl(originalFile.getFileUrl())
+                .deletedAt(null)
+                .build();
+    }
+
+    // 파일 복원을 위한 File 엔티티 생성 (고유한 이름 및 폴더ID로)
+    public static File toRestoredFileEntity(File originalFile, String uniqueName, Long targetFolderId) {
+        return File.builder()
+                .id(originalFile.getId())
+                .folderId(targetFolderId)
+                .workspaceMemberId(originalFile.getWorkspaceMemberId())
+                .name(uniqueName)
+                .type(originalFile.getType())
+                .objectKey(originalFile.getObjectKey())
+                .size(originalFile.getSize())
+                .fileUrl(originalFile.getFileUrl())
                 .deletedAt(null)
                 .build();
     }
@@ -82,10 +102,9 @@ public class FileConverter {
     public static FileResponseDto.Upload toUploadResponse(File file) {
         return new FileResponseDto.Upload(
                 file.getId(),
-                file.getFolderId(),
                 file.getName(),
                 file.getType().getKey(),
-                file.getObjectKey(),
+                file.getSize(),
                 file.getCreatedAt()
         );
     }
@@ -109,6 +128,7 @@ public class FileConverter {
                 .type(fileType)
                 .objectKey(objectKey)
                 .size(fileSize != null ? fileSize : 0L)
+                .fileUrl(null)
                 .build();
     }
 

--- a/src/main/java/com/project/syncly/domain/file/dto/FileRequestDto.java
+++ b/src/main/java/com/project/syncly/domain/file/dto/FileRequestDto.java
@@ -11,15 +11,24 @@ public class FileRequestDto {
     public record Update(
             @NotNull(message = "파일 이름은 필수입니다.")
             @Pattern(
-                    regexp = "^[a-zA-Z0-9가-힣_.-]{1,100}$",
-                    message = "파일 이름은 1~100자 사이의 한글, 영문, 숫자, '-', '_', '.'만 사용할 수 있습니다."
-            )String name
+                    regexp = "^[a-zA-Z0-9가-힣_. -]{1,100}$",
+                    message = "파일 이름은 1~100자 사이의 한글, 영문, 숫자, 공백, '-', '_', '.'만 사용할 수 있습니다."
+            )
+            @Schema(
+                    description = "새로운 파일명 (확장자 포함 필수)",
+                    example = "수정된파일명.pdf",
+                    requiredMode = Schema.RequiredMode.REQUIRED
+            )
+            String name
     ) {}
 
-    @Schema(description = "파일 업로드 Presigned URL 요청 DTO")
+    @Schema(description = "파일 업로드 Presigned URL 요청 DTO - S3 업로드를 위한 임시 URL 발급 요청")
     public record UploadPresignedUrl(
             @NotNull(message = "폴더 ID는 필수입니다.")
-            @Schema(description = "업로드할 폴더 ID")
+            @Schema(
+                    description = "업로드할 폴더 ID",
+                    example = "1"
+            )
             Long folderId,
 
             @NotNull(message = "파일 이름은 필수입니다.")
@@ -27,21 +36,30 @@ public class FileRequestDto {
                     regexp = "^[a-zA-Z0-9가-힣_. -]{1,200}$",
                     message = "파일 이름은 1~200자 사이의 한글, 영문, 숫자, 공백, '-', '_', '.'만 사용할 수 있습니다."
             )
-            @Schema(description = "파일 이름")
+            @Schema(
+                    description = "파일 이름 (확장자 포함 필수, MIME 타입 자동 추출)",
+                    example = "보고서.pdf",
+                    requiredMode = Schema.RequiredMode.REQUIRED
+            )
             String fileName,
 
-            @NotNull(message = "파일 MIME 타입은 필수입니다.")
-            @Schema(description = "파일 MIME 타입")
-            FileMimeType mimeType,
-
-            @Schema(description = "파일 크기(바이트)")
+            @Schema(
+                    description = "파일 크기 (바이트 단위, 선택사항)",
+                    example = "10485760",
+                    minimum = "1",
+                    maximum = "209715200"
+            )
             Long fileSize
     ) {}
 
     @Schema(description = "파일 업로드 완료 확인 요청 DTO")
     public record ConfirmUpload(
             @NotNull(message = "파일 이름은 필수입니다.")
-            @Schema(description = "파일 이름")
+            @Schema(
+                    description = "파일 이름 (확장자 포함 필수)",
+                    example = "보고서.pdf",
+                    requiredMode = Schema.RequiredMode.REQUIRED
+            )
             String fileName,
 
             @NotNull(message = "오브젝트 키는 필수입니다.")

--- a/src/main/java/com/project/syncly/domain/file/dto/FileResponseDto.java
+++ b/src/main/java/com/project/syncly/domain/file/dto/FileResponseDto.java
@@ -9,18 +9,25 @@ public class FileResponseDto {
 
     @Schema(description = "파일 업로드 응답 DTO")
     public record Upload(
+            @Schema(description = "파일 ID")
             Long id,
-            Long folderId,
+            @Schema(description = "파일명")
             String name,
+            @Schema(description = "파일 타입")
             String type,
-            String objectKey,
+            @Schema(description = "파일 크기 (바이트)")
+            Long size,
+            @Schema(description = "생성 일시")
             LocalDateTime createdAt
     ){}
 
     @Schema(description = "파일 이름 변경 응답 DTO")
     public record Update(
+            @Schema(description = "파일 ID")
             Long id,
+            @Schema(description = "수정된 파일명")
             String name,
+            @Schema(description = "수정 일시")
             LocalDateTime updatedAt
     ){}
 
@@ -34,7 +41,23 @@ public class FileResponseDto {
             @Schema(description = "임시 다운로드 URL (5분 유효)")
             String downloadUrl,
             @Schema(description = "파일 이름")
-            String fileName
+            String fileName,
+            @Schema(description = "파일 상세 정보")
+            FileInfo fileInfo
+    ){}
+
+    @Schema(description = "파일 정보 DTO")
+    public record FileInfo(
+            @Schema(description = "파일 ID")
+            Long id,
+            @Schema(description = "파일명")
+            String name,
+            @Schema(description = "파일 타입")
+            String type,
+            @Schema(description = "파일 크기 (바이트)")
+            Long size,
+            @Schema(description = "생성 일시")
+            LocalDateTime createdAt
     ){}
 
     @Schema(description = "파일 상세 정보 응답 DTO")

--- a/src/main/java/com/project/syncly/domain/file/entity/File.java
+++ b/src/main/java/com/project/syncly/domain/file/entity/File.java
@@ -35,6 +35,9 @@ public class File extends BaseTimeEntity {
     @Column(name = "size", nullable = false)
     private Long size;
 
+    @Column(name = "file_url")
+    private String fileUrl;
+
     @Column(name = "deleted_at")
     private java.time.LocalDateTime deletedAt;
 }

--- a/src/main/java/com/project/syncly/domain/file/exception/FileErrorCode.java
+++ b/src/main/java/com/project/syncly/domain/file/exception/FileErrorCode.java
@@ -20,7 +20,8 @@ public enum FileErrorCode implements BaseErrorCode {
     FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "File400_4", "파일 크기가 50MB를 초과했습니다."),
     UNSUPPORTED_FILE_TYPE(HttpStatus.BAD_REQUEST, "File400_5", "지원하지 않는 파일 형식입니다."),
     FOLDER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "File403_1", "해당 폴더에 접근할 수 없습니다."),
-    INVALID_UPLOAD_REQUEST(HttpStatus.BAD_REQUEST, "File400_6", "유효하지 않은 업로드 요청입니다. 업로드 권한이 없거나 만료되었습니다.");
+    INVALID_UPLOAD_REQUEST(HttpStatus.BAD_REQUEST, "File400_6", "유효하지 않은 업로드 요청입니다. 업로드 권한이 없거나 만료되었습니다."),
+    MISSING_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "File400_7", "파일명에 확장자가 포함되어야 합니다. (예: 파일명.jpg)");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/project/syncly/domain/file/service/FileQueryService.java
+++ b/src/main/java/com/project/syncly/domain/file/service/FileQueryService.java
@@ -68,7 +68,17 @@ public class FileQueryService {
 
         try {
             String downloadUrl = s3Util.createPresignedGetUrlForDownload(file.getObjectKey(), file.getName());
-            return new FileResponseDto.DownloadUrl(downloadUrl, file.getName());
+
+            // 파일 상세 정보 생성 (보안을 고려하여 필요한 정보만)
+            FileResponseDto.FileInfo fileInfo = new FileResponseDto.FileInfo(
+                    file.getId(),
+                    file.getName(),
+                    file.getType().getKey(),
+                    file.getSize(),
+                    file.getCreatedAt()
+            );
+
+            return new FileResponseDto.DownloadUrl(downloadUrl, file.getName(), fileInfo);
         } catch (Exception e) {
             throw new FileException(FileErrorCode.FILE_DOWNLOAD_FAILED);
         }

--- a/src/main/java/com/project/syncly/domain/s3/enums/FileMimeType.java
+++ b/src/main/java/com/project/syncly/domain/s3/enums/FileMimeType.java
@@ -11,9 +11,33 @@ import java.util.Arrays;
 
 @Getter
 public enum FileMimeType implements BaseEnum {
-    JPG("image/jpg", "jpg"),
+    // 이미지 파일
+    JPG("image/jpeg", "jpg"),
     JPEG("image/jpeg", "jpeg"),
     PNG("image/png", "png"),
+    GIF("image/gif", "gif"),
+    BMP("image/bmp", "bmp"),
+    SVG("image/svg+xml", "svg"),
+    WEBP("image/webp", "webp"),
+
+    // 동영상 파일
+    MP4("video/mp4", "mp4"),
+    AVI("video/x-msvideo", "avi"),
+    MKV("video/x-matroska", "mkv"),
+    MOV("video/quicktime", "mov"),
+    WMV("video/x-ms-wmv", "wmv"),
+    FLV("video/x-flv", "flv"),
+    WEBM("video/webm", "webm"),
+
+    // 문서 파일
+    PDF("application/pdf", "pdf"),
+    DOC("application/msword", "doc"),
+    DOCX("application/vnd.openxmlformats-officedocument.wordprocessingml.document", "docx"),
+    XLS("application/vnd.ms-excel", "xls"),
+    XLSX("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "xlsx"),
+    PPT("application/vnd.ms-powerpoint", "ppt"),
+    PPTX("application/vnd.openxmlformats-officedocument.presentationml.presentation", "pptx"),
+    TXT("text/plain", "txt"),
     ;
 
     private final String key;
@@ -33,9 +57,34 @@ public enum FileMimeType implements BaseEnum {
     // 확장자 -> mime
     public static FileMimeType fromExtension(String ext) {
         return switch (ext.toLowerCase()) {
+            // 이미지 파일
             case "jpg" -> JPG;
             case "jpeg" -> JPEG;
             case "png" -> PNG;
+            case "gif" -> GIF;
+            case "bmp" -> BMP;
+            case "svg" -> SVG;
+            case "webp" -> WEBP;
+
+            // 동영상 파일
+            case "mp4" -> MP4;
+            case "avi" -> AVI;
+            case "mkv" -> MKV;
+            case "mov" -> MOV;
+            case "wmv" -> WMV;
+            case "flv" -> FLV;
+            case "webm" -> WEBM;
+
+            // 문서 파일
+            case "pdf" -> PDF;
+            case "doc" -> DOC;
+            case "docx" -> DOCX;
+            case "xls" -> XLS;
+            case "xlsx" -> XLSX;
+            case "ppt" -> PPT;
+            case "pptx" -> PPTX;
+            case "txt" -> TXT;
+
             default -> throw new S3Exception(S3ErrorCode.UNSUPPORTED_FILE_EXTENSION);
         };
     }

--- a/src/main/java/com/project/syncly/domain/s3/util/S3Util.java
+++ b/src/main/java/com/project/syncly/domain/s3/util/S3Util.java
@@ -20,6 +20,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.Duration;
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 @Component
 @RequiredArgsConstructor
@@ -53,12 +55,16 @@ public class S3Util {
 
     public String createPresignedGetUrlForDownload(String objectKey, String fileName) {
         try {
+            // 한글 파일명을 RFC 5987 표준에 맞게 인코딩
+            String encodedFileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8);
+            String contentDisposition = "attachment; filename*=UTF-8''" + encodedFileName;
+
             //ContentDisposition는 이 파일의 행동을 강제한다(download, view)
             //ContentType는 랜더링 방식을 결정한다. 어떤 뷰어를 쓸 것인지
             GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                     .bucket(bucket)
                     .key(objectKey)
-                    .responseContentDisposition("attachment; filename=\"" + fileName + "\"")//브라우저가 무조건 다운로드 창 띄움
+                    .responseContentDisposition(contentDisposition)//브라우저가 무조건 다운로드 창 띄움
                     .build();
 
             GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
@@ -85,5 +91,6 @@ public class S3Util {
             throw new S3Exception(S3ErrorCode.DELETE_FAILED);
         }
     }
+
 
 }


### PR DESCRIPTION
# ☝️Issue Number

- #75 

##  📌 개요

- 전체적인 파일 api 점검 및 삭제시 복원 api 구현

## 🔁 변경 사항
[feat: File 엔티티에 file_url 필드 추가 및 FileConverter 업데이트](https://github.com/SynclyProject/Syncly-BE/commit/111024b5f7f77bb8aa51d92773e580888970e06c)

[feat: 파일명 확장자 필수 검증 로직 추가](https://github.com/SynclyProject/Syncly-BE/commit/37fe44f389eab90a53eb01feb08b798d9c271d17)

[feat: 파일 API 응답 구조 개선](https://github.com/SynclyProject/Syncly-BE/commit/994aea9142dfd12092903b73f01b7b53a86d333d)

[docs: 파일 API Swagger 문서 및 DTO 스키마 개선](https://github.com/SynclyProject/Syncly-BE/commit/d73c46cec8ffd0f6ad3419ce58ac20fdc7075359)

[fix: S3 다운로드 URL 한글 파일명 인코딩 개선](https://github.com/SynclyProject/Syncly-BE/commit/ed544bcfb3ed5d0320740d26f0dced252fd2ee3a)

## 📸 스크린샷
아래 api 모두 정상 작동하는 점 확인했습니다.
<img width="795" height="346" alt="스크린샷 2025-09-25 오후 4 59 23" src="https://github.com/user-attachments/assets/a14614c4-b5e5-4d64-b9fa-2abb88a2ca00" />


## 👀 기타 더 이야기해볼 점
  - 한글 파일명 처리 시 URL 인코딩 관련하여 추가적인 테스트가 필요할 수 있음