### PR TITLE
🐛 fix: 새롭게 생성한 폴더가 목록 조회에 안 나오는 오류 해결

### DIFF
--- a/src/main/java/com/project/syncly/domain/folder/service/FolderCommandServiceImpl.java
+++ b/src/main/java/com/project/syncly/domain/folder/service/FolderCommandServiceImpl.java
@@ -12,6 +12,7 @@ import com.project.syncly.domain.folder.exception.FolderException;
 import com.project.syncly.domain.folder.repository.FolderClosureRepository;
 import com.project.syncly.domain.folder.repository.FolderRepository;
 import com.project.syncly.domain.workspace.repository.WorkspaceRepository;
+import com.project.syncly.domain.workspaceMember.entity.WorkspaceMember;
 import com.project.syncly.domain.workspaceMember.repository.WorkspaceMemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,10 +43,10 @@ public class FolderCommandServiceImpl implements FolderCommandService{
         Long parentId = requestDto.parentId();
         log.info("memberId: {}", memberId);
 
-        // [0] 워크스페이스 회원 여부 검증
-        if (!workspaceMemberRepository.existsByWorkspaceIdAndMemberId(workspaceId, memberId)) {
-            throw new FolderException(FolderErrorCode.FORBIDDEN_ACCESS);
-        }
+        // [0] 워크스페이스 회원 여부 검증 및 실제 WorkspaceMember ID 조회
+        WorkspaceMember workspaceMember = workspaceMemberRepository
+            .findByWorkspaceIdAndMemberId(workspaceId, memberId)
+            .orElseThrow(() -> new FolderException(FolderErrorCode.FORBIDDEN_ACCESS));
 
         // [1] 이름 검증
         String name = requestDto.name();
@@ -96,9 +97,9 @@ public class FolderCommandServiceImpl implements FolderCommandService{
             throw new FolderException(FolderErrorCode.DUPLICATE_FOLDER_NAME);
         }
 
-        // [5] 폴더 생성 - parentId를 업데이트된 값으로 사용
+        // [5] 폴더 생성 - parentId를 업데이트된 값으로 사용, 올바른 workspaceMemberId 사용
         FolderRequestDto.Create updatedRequestDto = new FolderRequestDto.Create(parentId, requestDto.name());
-        Folder folder = folderRepository.save(FolderConverter.toFolder(workspaceId, updatedRequestDto, memberId));
+        Folder folder = folderRepository.save(FolderConverter.toFolder(workspaceId, updatedRequestDto, workspaceMember.getId()));
         folderClosureCommandService.updateOnCreate(parentId, folder.getId());
         return FolderConverter.toFolderResponse(folder);
     }
@@ -133,10 +134,10 @@ public class FolderCommandServiceImpl implements FolderCommandService{
     @Override
     public FolderResponseDto.Update updateFolderName(Long workspaceId, Long folderId, FolderRequestDto.Update requestDto, Long memberId) {
 
-        // [1] 워크스페이스 회원 여부 검증
-        if (!workspaceMemberRepository.existsByWorkspaceIdAndMemberId(workspaceId, memberId)) {
-            throw new FolderException(FolderErrorCode.FORBIDDEN_ACCESS);
-        }
+        // [1] 워크스페이스 회원 여부 검증 및 실제 WorkspaceMember ID 조회
+        WorkspaceMember workspaceMember = workspaceMemberRepository
+            .findByWorkspaceIdAndMemberId(workspaceId, memberId)
+            .orElseThrow(() -> new FolderException(FolderErrorCode.FORBIDDEN_ACCESS));
 
         // [2] 이름 검증
         String newName = requestDto.name();
@@ -174,10 +175,10 @@ public class FolderCommandServiceImpl implements FolderCommandService{
     @Override
     public FolderResponseDto.Message deleteFolder(Long workspaceId, Long folderId, Long memberId) {
 
-        // [1] 워크스페이스 회원 여부 검증
-        if (!workspaceMemberRepository.existsByWorkspaceIdAndMemberId(workspaceId, memberId)) {
-            throw new FolderException(FolderErrorCode.FORBIDDEN_ACCESS);
-        }
+        // [1] 워크스페이스 회원 여부 검증 및 실제 WorkspaceMember ID 조회
+        WorkspaceMember workspaceMember = workspaceMemberRepository
+            .findByWorkspaceIdAndMemberId(workspaceId, memberId)
+            .orElseThrow(() -> new FolderException(FolderErrorCode.FORBIDDEN_ACCESS));
 
         // [2] 폴더 존재 여부 및 워크스페이스 소속 확인
         Folder folder = folderRepository.findByIdAndWorkspaceId(folderId, workspaceId)
@@ -217,10 +218,10 @@ public class FolderCommandServiceImpl implements FolderCommandService{
     @Override
     public FolderResponseDto.Message restoreFolder(Long workspaceId, Long folderId, Long memberId) {
 
-        // [1] 워크스페이스 회원 여부 검증
-        if (!workspaceMemberRepository.existsByWorkspaceIdAndMemberId(workspaceId, memberId)) {
-            throw new FolderException(FolderErrorCode.FORBIDDEN_ACCESS);
-        }
+        // [1] 워크스페이스 회원 여부 검증 및 실제 WorkspaceMember ID 조회
+        WorkspaceMember workspaceMember = workspaceMemberRepository
+            .findByWorkspaceIdAndMemberId(workspaceId, memberId)
+            .orElseThrow(() -> new FolderException(FolderErrorCode.FORBIDDEN_ACCESS));
 
         // [2] 삭제된 폴더 존재 여부 확인
         Folder folder = folderRepository.findDeletedByIdAndWorkspaceId(folderId, workspaceId)


### PR DESCRIPTION
# ☝️Issue Number
close # 이슈번호

##  📌 개요

- 새롭게 생성한 폴더가 목록 조회에 안 나왔던 오류를 해결했습니다.

## 🔁 변경 사항
[fix: memberId를 workspaceId에 사용하여 오류가 생겼던 폴더 생성 로직 수정](https://github.com/SynclyProject/Syncly-BE/commit/f162d903f21d70f96b6225bcfcc02f33dc07fdff)

## 📸 스크린샷
<img width="577" height="497" alt="스크린샷 2025-09-30 오전 12 15 24" src="https://github.com/user-attachments/assets/8ee2b7b6-c8eb-4939-8e24-c151e83ace9a" />
<img width="222" height="281" alt="스크린샷 2025-09-30 오전 12 15 43" src="https://github.com/user-attachments/assets/82867c90-172f-468a-8575-dc248b1c0647" />

## 👀 기타 더 이야기해볼 점