### PR TITLE
🐛 fix: 회원가입시 루트폴더 생성 시 뜨는 오류 수정

### DIFF
--- a/src/main/java/com/project/syncly/domain/folder/service/FolderCommandServiceImpl.java
+++ b/src/main/java/com/project/syncly/domain/folder/service/FolderCommandServiceImpl.java
@@ -116,11 +116,17 @@ public class FolderCommandServiceImpl implements FolderCommandService{
             throw new FolderException(FolderErrorCode.WORKSPACE_NOT_FOUND);
         }
 
+        // 워크스페이스의 매니저 조회
+        WorkspaceMember manager = workspaceMemberRepository
+                .findFirstByWorkspaceId(workspaceId)
+                .orElseThrow(() -> new FolderException(FolderErrorCode.FORBIDDEN_ACCESS));
+
         // 루트 폴더 생성 (parentId는 null, name은 "root")
         Folder rootFolder = Folder.builder()
                 .workspaceId(workspaceId)
                 .parentId(null)
                 .name("root")
+                .workspaceMemberId(manager.getId())
                 .build();
 
         Folder savedFolder = folderRepository.save(rootFolder);

--- a/src/main/java/com/project/syncly/domain/workspaceMember/repository/WorkspaceMemberRepository.java
+++ b/src/main/java/com/project/syncly/domain/workspaceMember/repository/WorkspaceMemberRepository.java
@@ -57,4 +57,7 @@ public interface WorkspaceMemberRepository extends JpaRepository<WorkspaceMember
 
     List<WorkspaceMember> findAllByMember(Member member);
 
+    //워크스페이스의 첫 번째 멤버 조회 (루트 폴더 생성 시 사용)
+    Optional<WorkspaceMember> findFirstByWorkspaceId(Long workspaceId);
+
 }


### PR DESCRIPTION
# ☝️Issue Number
Close#93

##  📌 개요

- 🐛 fix: 회원가입시 루트폴더 생성 시 뜨는 오류 수정

## 🔁 변경 사항
[fix: 회원가입시 workspaceMemberId 필드를 빼먹은 오류 수정](https://github.com/SynclyProject/Syncly-BE/commit/d6416b0d0c41f58b49a4e2e55451f8c22beaf323)

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점