### PR TITLE
🐛 fix: 폴더, 파일 목록 조회 시 프로필 object key null 반환되는 오류 수정

### DIFF
--- a/src/main/java/com/project/syncly/domain/folder/repository/FolderRepository.java
+++ b/src/main/java/com/project/syncly/domain/folder/repository/FolderRepository.java
@@ -68,7 +68,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 특정 폴더의 하위 폴더 목록 조회 (워크스페이스 멤버 정보 포함)
     @Query("""
         SELECT f.id, f.name, f.createdAt, f.updatedAt,
-               wm.id as wmId, wm.name as wmName, wm.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
         FROM Folder f
         JOIN WorkspaceMember wm ON f.workspaceMemberId = wm.id
         WHERE f.parentId = :folderId
@@ -87,7 +87,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 특정 폴더의 파일 목록 조회 (워크스페이스 멤버 정보 포함)
     @Query("""
         SELECT fi.id, fi.name, fi.createdAt, fi.updatedAt, fi.size, fi.objectKey, CAST(fi.type AS string),
-               wm.id as wmId, wm.name as wmName, wm.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
         FROM File fi
         JOIN WorkspaceMember wm ON fi.workspaceMemberId = wm.id
         WHERE fi.folderId = :folderId
@@ -106,7 +106,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 폴더 조회 (latest 정렬)
     @Query("""
         SELECT f.id, f.name, f.createdAt, f.updatedAt,
-               wm.id as wmId, wm.name as wmName, wm.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
         FROM Folder f
         JOIN WorkspaceMember wm ON f.workspaceMemberId = wm.id
         WHERE f.parentId = :folderId
@@ -125,7 +125,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 폴더 조회 (alphabet 정렬)
     @Query("""
         SELECT f.id, f.name, f.createdAt, f.updatedAt,
-               wm.id as wmId, wm.name as wmName, wm.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
         FROM Folder f
         JOIN WorkspaceMember wm ON f.workspaceMemberId = wm.id
         WHERE f.parentId = :folderId
@@ -144,7 +144,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 파일 조회 (latest 정렬)
     @Query("""
         SELECT fi.id, fi.name, fi.createdAt, fi.updatedAt, fi.size, fi.objectKey, CAST(fi.type AS string),
-               wm.id as wmId, wm.name as wmName, wm.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
         FROM File fi
         JOIN WorkspaceMember wm ON fi.workspaceMemberId = wm.id
         WHERE fi.folderId = :folderId
@@ -163,7 +163,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 파일 조회 (alphabet 정렬)
     @Query("""
         SELECT fi.id, fi.name, fi.createdAt, fi.updatedAt, fi.size, fi.objectKey, CAST(fi.type AS string),
-               wm.id as wmId, wm.name as wmName, wm.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
         FROM File fi
         JOIN WorkspaceMember wm ON fi.workspaceMemberId = wm.id
         WHERE fi.folderId = :folderId
@@ -182,7 +182,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 워크스페이스 휴지통 - 삭제된 폴더 목록 조회 (워크스페이스 멤버 정보 포함)
     @Query("""
         SELECT f.id, f.name, f.createdAt, f.updatedAt,
-               wm.id as wmId, wm.name as wmName, wm.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
         FROM Folder f
         JOIN WorkspaceMember wm ON f.workspaceMemberId = wm.id
         WHERE f.workspaceId = :workspaceId
@@ -201,7 +201,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 워크스페이스 휴지통 - 삭제된 파일 목록 조회 (워크스페이스 멤버 정보 포함)
     @Query("""
         SELECT fi.id, fi.name, fi.createdAt, fi.updatedAt, fi.size, fi.objectKey, CAST(fi.type AS string),
-               wm.id as wmId, wm.name as wmName, wm.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
         FROM File fi
         JOIN WorkspaceMember wm ON fi.workspaceMemberId = wm.id
         JOIN Folder f ON fi.folderId = f.id
@@ -221,7 +221,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 휴지통 폴더 조회 (latest 정렬)
     @Query("""
         SELECT f.id, f.name, f.createdAt, f.updatedAt,
-               wm.id as wmId, wm.name as wmName, wm.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
         FROM Folder f
         JOIN WorkspaceMember wm ON f.workspaceMemberId = wm.id
         WHERE f.workspaceId = :workspaceId
@@ -240,7 +240,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 휴지통 폴더 조회 (alphabet 정렬)
     @Query("""
         SELECT f.id, f.name, f.createdAt, f.updatedAt,
-               wm.id as wmId, wm.name as wmName, wm.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
         FROM Folder f
         JOIN WorkspaceMember wm ON f.workspaceMemberId = wm.id
         WHERE f.workspaceId = :workspaceId
@@ -259,7 +259,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 휴지통 파일 조회 (latest 정렬)
     @Query("""
         SELECT fi.id, fi.name, fi.createdAt, fi.updatedAt, fi.size, fi.objectKey, CAST(fi.type AS string),
-               wm.id as wmId, wm.name as wmName, wm.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
         FROM File fi
         JOIN WorkspaceMember wm ON fi.workspaceMemberId = wm.id
         JOIN Folder f ON fi.folderId = f.id
@@ -279,7 +279,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 휴지통 파일 조회 (alphabet 정렬)
     @Query("""
         SELECT fi.id, fi.name, fi.createdAt, fi.updatedAt, fi.size, fi.objectKey, CAST(fi.type AS string),
-               wm.id as wmId, wm.name as wmName, wm.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
         FROM File fi
         JOIN WorkspaceMember wm ON fi.workspaceMemberId = wm.id
         JOIN Folder f ON fi.folderId = f.id


### PR DESCRIPTION
# ☝️Issue Number
#100 

##  📌 개요
- 폴더, 파일 목록 조회 시 프로필 object key null 반환되는 오류 수정

## 🔁 변경 사항
[fix: 프로필이미지를 workspaceMember가 아닌 member에서 갖고오도록 수정](https://github.com/SynclyProject/Syncly-BE/commit/09184e5ee5fde9b038b762224bf56c5331a9f00e)

## 📸 스크린샷
<img width="620" height="291" alt="스크린샷 2025-10-03 오후 5 23 34" src="https://github.com/user-attachments/assets/3cce4514-6d66-4512-abb3-b220590df5db" />


## 👀 기타 더 이야기해볼 점