### PR TITLE
🐛 fix: 팀원목록/채팅/파일폴더 api에서 object key 반환하도록 수정

### DIFF
--- a/src/main/java/com/project/syncly/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/com/project/syncly/domain/chat/converter/ChatConverter.java
@@ -27,7 +27,7 @@ public class ChatConverter {
                 .workspaceId(chatMessage.getWorkspace().getId())
                 .senderId(chatMessage.getSender().getId())
                 .senderName(chatMessage.getSender().getName())
-                .senderProfileImage(chatMessage.getSender().getProfileImage())
+                .senderProfileImage(chatMessage.getSender().getMember().getProfileImage())
                 .msgId(chatMessage.getMsgId())
                 .seq(chatMessage.getSeq())
                 .content(chatMessage.getContent())

--- a/src/main/java/com/project/syncly/domain/file/controller/FileController.java
+++ b/src/main/java/com/project/syncly/domain/file/controller/FileController.java
@@ -29,6 +29,7 @@ public class FileController {
 
     private final FileCommandService fileCommandService;
     private final FileQueryService fileQueryService;
+    private final WorkspaceMemberRepository workspaceMemberRepository;
 
     @PostMapping("/{workspaceId}/files/presigned-url")
     @Operation(
@@ -63,8 +64,12 @@ public class FileController {
             @AuthenticationPrincipal PrincipalDetails userDetails
     ) {
         Long memberId = Long.valueOf(userDetails.getName());
+        Long workspaceMemberId = workspaceMemberRepository.findByWorkspaceIdAndMemberId(workspaceId, memberId)
+                .orElseThrow(() -> new RuntimeException("워크스페이스 멤버를 찾을 수 없습니다."))
+                .getId();
+
         FileResponseDto.PresignedUrl responseDto = fileCommandService.generatePresignedUrl(
-                workspaceId, requestDto.folderId(), memberId, requestDto);
+                workspaceId, requestDto.folderId(), workspaceMemberId, requestDto);
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CustomResponse.success(HttpStatus.CREATED, responseDto));
@@ -94,8 +99,12 @@ public class FileController {
             @AuthenticationPrincipal PrincipalDetails userDetails
     ) {
         Long memberId = Long.valueOf(userDetails.getName());
+        Long workspaceMemberId = workspaceMemberRepository.findByWorkspaceIdAndMemberId(workspaceId, memberId)
+                .orElseThrow(() -> new RuntimeException("워크스페이스 멤버를 찾을 수 없습니다."))
+                .getId();
+
         FileResponseDto.Upload responseDto = fileCommandService.confirmFileUpload(
-                workspaceId, memberId, requestDto);
+                workspaceId, workspaceMemberId, requestDto);
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CustomResponse.success(HttpStatus.CREATED, responseDto));
@@ -109,7 +118,11 @@ public class FileController {
             @AuthenticationPrincipal PrincipalDetails userDetails
     ) {
         Long memberId = Long.valueOf(userDetails.getName());
-        FileResponseDto.DownloadUrl responseDto = fileQueryService.getFileDownloadUrl(workspaceId, fileId, memberId);
+        Long workspaceMemberId = workspaceMemberRepository.findByWorkspaceIdAndMemberId(workspaceId, memberId)
+                .orElseThrow(() -> new RuntimeException("워크스페이스 멤버를 찾을 수 없습니다."))
+                .getId();
+
+        FileResponseDto.DownloadUrl responseDto = fileQueryService.getFileDownloadUrl(workspaceId, fileId, workspaceMemberId);
 
         return ResponseEntity.ok(CustomResponse.success(HttpStatus.OK, responseDto));
     }
@@ -137,8 +150,12 @@ public class FileController {
             @AuthenticationPrincipal PrincipalDetails userDetails
     ) {
         Long memberId = Long.valueOf(userDetails.getName());
+        Long workspaceMemberId = workspaceMemberRepository.findByWorkspaceIdAndMemberId(workspaceId, memberId)
+                .orElseThrow(() -> new RuntimeException("워크스페이스 멤버를 찾을 수 없습니다."))
+                .getId();
+
         FileResponseDto.Update responseDto = fileCommandService.updateFileName(
-                workspaceId, fileId, memberId, requestDto);
+                workspaceId, fileId, workspaceMemberId, requestDto);
 
         return ResponseEntity.ok(CustomResponse.success(HttpStatus.OK, responseDto));
     }
@@ -151,8 +168,12 @@ public class FileController {
             @AuthenticationPrincipal PrincipalDetails userDetails
     ) {
         Long memberId = Long.valueOf(userDetails.getName());
+        Long workspaceMemberId = workspaceMemberRepository.findByWorkspaceIdAndMemberId(workspaceId, memberId)
+                .orElseThrow(() -> new RuntimeException("워크스페이스 멤버를 찾을 수 없습니다."))
+                .getId();
+
         FileResponseDto.Message responseDto = fileCommandService.deleteFile(
-                workspaceId, fileId, memberId);
+                workspaceId, fileId, workspaceMemberId);
 
         return ResponseEntity.ok(CustomResponse.success(HttpStatus.OK, responseDto));
     }
@@ -165,8 +186,12 @@ public class FileController {
             @AuthenticationPrincipal PrincipalDetails userDetails
     ) {
         Long memberId = Long.valueOf(userDetails.getName());
+        Long workspaceMemberId = workspaceMemberRepository.findByWorkspaceIdAndMemberId(workspaceId, memberId)
+                .orElseThrow(() -> new RuntimeException("워크스페이스 멤버를 찾을 수 없습니다."))
+                .getId();
+
         FileResponseDto.Message responseDto = fileCommandService.restoreFile(
-                workspaceId, fileId, memberId);
+                workspaceId, fileId, workspaceMemberId);
 
         return ResponseEntity.ok(CustomResponse.success(HttpStatus.OK, responseDto));
     }
@@ -179,8 +204,12 @@ public class FileController {
             @AuthenticationPrincipal PrincipalDetails userDetails
     ) {
         Long memberId = Long.valueOf(userDetails.getName());
+        Long workspaceMemberId = workspaceMemberRepository.findByWorkspaceIdAndMemberId(workspaceId, memberId)
+                .orElseThrow(() -> new RuntimeException("워크스페이스 멤버를 찾을 수 없습니다."))
+                .getId();
+
         FileResponseDto.Message responseDto = fileCommandService.hardDeleteFile(
-                workspaceId, fileId, memberId);
+                workspaceId, fileId, workspaceMemberId);
 
         return ResponseEntity.ok(CustomResponse.success(HttpStatus.OK, responseDto));
     }

--- a/src/main/java/com/project/syncly/domain/file/dto/FileRequestDto.java
+++ b/src/main/java/com/project/syncly/domain/file/dto/FileRequestDto.java
@@ -11,8 +11,8 @@ public class FileRequestDto {
     public record Update(
             @NotNull(message = "파일 이름은 필수입니다.")
             @Pattern(
-                    regexp = "^[a-zA-Z0-9가-힣_. ()\\-\\[\\]]{1,100}$",
-                    message = "파일 이름은 1~100자 사이의 한글, 영문, 숫자, 공백, '-', '_', '.', '(', ')', '[', ']'만 사용할 수 있습니다."
+                    regexp = "^.{1,255}$",
+                    message = "파일 이름은 1~255자 사이여야 합니다."
             )
             @Schema(
                     description = "새로운 파일명 (확장자 포함 필수)",
@@ -33,8 +33,8 @@ public class FileRequestDto {
 
             @NotNull(message = "파일 이름은 필수입니다.")
             @Pattern(
-                    regexp = "^[a-zA-Z0-9가-힣_. ()\\-\\[\\]]{1,200}$",
-                    message = "파일 이름은 1~200자 사이의 한글, 영문, 숫자, 공백, '-', '_', '.', '(', ')', '[', ']'만 사용할 수 있습니다."
+                    regexp = "^.{1,255}$",
+                    message = "파일 이름은 1~255자 사이여야 합니다."
             )
             @Schema(
                     description = "파일 이름 (확장자 포함 필수, MIME 타입 자동 추출)",

--- a/src/main/java/com/project/syncly/domain/file/enums/FileType.java
+++ b/src/main/java/com/project/syncly/domain/file/enums/FileType.java
@@ -35,8 +35,12 @@ public enum FileType implements BaseEnum {
 
         String ext = fileName.substring(fileName.lastIndexOf('.') + 1).toLowerCase();
         return switch (ext) {
+            // 이미지
             case "jpg", "jpeg", "png", "gif", "bmp", "svg", "webp" -> IMAGE;
+
+            // 동영상
             case "mp4", "avi", "mkv", "mov", "wmv", "flv", "webm" -> VIDEO;
+
             default -> FILE;
         };
     }

--- a/src/main/java/com/project/syncly/domain/file/service/FileCommandServiceImpl.java
+++ b/src/main/java/com/project/syncly/domain/file/service/FileCommandServiceImpl.java
@@ -193,9 +193,7 @@ public class FileCommandServiceImpl implements FileCommandService {
 
     // 워크스페이스 멤버십 검증
     private void validateWorkspaceMembership(Long workspaceId, Long workspaceMemberId) {
-        // TODO: workspaceMemberId로 직접 확인하는 방법으로 변경 필요
-        // 현재는 임시로 memberId로 확인
-        if (!workspaceMemberRepository.existsByWorkspaceIdAndMemberId(workspaceId, workspaceMemberId)) {
+        if (!workspaceMemberRepository.findByWorkspaceIdAndId(workspaceId, workspaceMemberId).isPresent()) {
             throw new WorkspaceException(WorkspaceErrorCode.NOT_WORKSPACE_MEMBER);
         }
     }

--- a/src/main/java/com/project/syncly/domain/file/service/FileCommandServiceImpl.java
+++ b/src/main/java/com/project/syncly/domain/file/service/FileCommandServiceImpl.java
@@ -44,7 +44,15 @@ public class FileCommandServiceImpl implements FileCommandService {
         validateFileNameHasExtension(requestDto.fileName());
 
         String uniqueFileName = generateUniqueFileName(folderId, requestDto.fileName());
-        String objectKey = "uploads/" + java.util.UUID.randomUUID() + "_" + uniqueFileName;
+
+        // 확장자 추출
+        String extension = "";
+        if (uniqueFileName.contains(".")) {
+            extension = uniqueFileName.substring(uniqueFileName.lastIndexOf('.'));
+        }
+
+        // S3 objectKey는 UUID + 확장자만 사용 (한글/특수문자 URL 인코딩 문제 방지)
+        String objectKey = "uploads/" + java.util.UUID.randomUUID() + extension;
 
         // 파일명에서 mimeType 자동 추출
         FileMimeType mimeType = FileMimeType.extractMimeType(uniqueFileName);

--- a/src/main/java/com/project/syncly/domain/file/service/FileQueryServiceImpl.java
+++ b/src/main/java/com/project/syncly/domain/file/service/FileQueryServiceImpl.java
@@ -96,9 +96,7 @@ public class FileQueryServiceImpl implements FileQueryService {
 
     // 워크스페이스 멤버십 검증
     private void validateWorkspaceMembership(Long workspaceId, Long workspaceMemberId) {
-        // TODO: workspaceMemberId로 직접 확인하는 방법으로 변경 필요
-        // 현재는 임시로 memberId로 확인
-        if (!workspaceMemberRepository.existsByWorkspaceIdAndMemberId(workspaceId, workspaceMemberId)) {
+        if (!workspaceMemberRepository.findByWorkspaceIdAndId(workspaceId, workspaceMemberId).isPresent()) {
             throw new WorkspaceException(WorkspaceErrorCode.NOT_WORKSPACE_MEMBER);
         }
     }

--- a/src/main/java/com/project/syncly/domain/folder/repository/FolderRepository.java
+++ b/src/main/java/com/project/syncly/domain/folder/repository/FolderRepository.java
@@ -68,7 +68,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 특정 폴더의 하위 폴더 목록 조회 (워크스페이스 멤버 정보 포함)
     @Query("""
         SELECT f.id, f.name, f.createdAt, f.updatedAt,
-               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
+               wm.id as wmId, m.name as wmName, m.profileImage as wmProfileImage
         FROM Folder f
         JOIN WorkspaceMember wm ON f.workspaceMemberId = wm.id
         JOIN wm.member m
@@ -88,7 +88,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 특정 폴더의 파일 목록 조회 (워크스페이스 멤버 정보 포함)
     @Query("""
         SELECT fi.id, fi.name, fi.createdAt, fi.updatedAt, fi.size, fi.objectKey, CAST(fi.type AS string),
-               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
+               wm.id as wmId, m.name as wmName, m.profileImage as wmProfileImage
         FROM File fi
         JOIN WorkspaceMember wm ON fi.workspaceMemberId = wm.id
         JOIN wm.member m
@@ -108,7 +108,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 폴더 조회 (latest 정렬)
     @Query("""
         SELECT f.id, f.name, f.createdAt, f.updatedAt,
-               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
+               wm.id as wmId, m.name as wmName, m.profileImage as wmProfileImage
         FROM Folder f
         JOIN WorkspaceMember wm ON f.workspaceMemberId = wm.id
         JOIN wm.member m
@@ -128,7 +128,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 폴더 조회 (alphabet 정렬)
     @Query("""
         SELECT f.id, f.name, f.createdAt, f.updatedAt,
-               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
+               wm.id as wmId, m.name as wmName, m.profileImage as wmProfileImage
         FROM Folder f
         JOIN WorkspaceMember wm ON f.workspaceMemberId = wm.id
         JOIN wm.member m
@@ -148,7 +148,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 파일 조회 (latest 정렬)
     @Query("""
         SELECT fi.id, fi.name, fi.createdAt, fi.updatedAt, fi.size, fi.objectKey, CAST(fi.type AS string),
-               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
+               wm.id as wmId, m.name as wmName, m.profileImage as wmProfileImage
         FROM File fi
         JOIN WorkspaceMember wm ON fi.workspaceMemberId = wm.id
         JOIN wm.member m
@@ -168,7 +168,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 파일 조회 (alphabet 정렬)
     @Query("""
         SELECT fi.id, fi.name, fi.createdAt, fi.updatedAt, fi.size, fi.objectKey, CAST(fi.type AS string),
-               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
+               wm.id as wmId, m.name as wmName, m.profileImage as wmProfileImage
         FROM File fi
         JOIN WorkspaceMember wm ON fi.workspaceMemberId = wm.id
         JOIN wm.member m
@@ -188,7 +188,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 워크스페이스 휴지통 - 삭제된 폴더 목록 조회 (워크스페이스 멤버 정보 포함)
     @Query("""
         SELECT f.id, f.name, f.createdAt, f.updatedAt,
-               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
+               wm.id as wmId, m.name as wmName, m.profileImage as wmProfileImage
         FROM Folder f
         JOIN WorkspaceMember wm ON f.workspaceMemberId = wm.id
         JOIN wm.member m
@@ -208,7 +208,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 워크스페이스 휴지통 - 삭제된 파일 목록 조회 (워크스페이스 멤버 정보 포함)
     @Query("""
         SELECT fi.id, fi.name, fi.createdAt, fi.updatedAt, fi.size, fi.objectKey, CAST(fi.type AS string),
-               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
+               wm.id as wmId, m.name as wmName, m.profileImage as wmProfileImage
         FROM File fi
         JOIN WorkspaceMember wm ON fi.workspaceMemberId = wm.id
         JOIN wm.member m
@@ -229,7 +229,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 휴지통 폴더 조회 (latest 정렬)
     @Query("""
         SELECT f.id, f.name, f.createdAt, f.updatedAt,
-               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
+               wm.id as wmId, m.name as wmName, m.profileImage as wmProfileImage
         FROM Folder f
         JOIN WorkspaceMember wm ON f.workspaceMemberId = wm.id
         JOIN wm.member m
@@ -249,7 +249,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 휴지통 폴더 조회 (alphabet 정렬)
     @Query("""
         SELECT f.id, f.name, f.createdAt, f.updatedAt,
-               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
+               wm.id as wmId, m.name as wmName, m.profileImage as wmProfileImage
         FROM Folder f
         JOIN WorkspaceMember wm ON f.workspaceMemberId = wm.id
         JOIN wm.member m
@@ -269,7 +269,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 휴지통 파일 조회 (latest 정렬)
     @Query("""
         SELECT fi.id, fi.name, fi.createdAt, fi.updatedAt, fi.size, fi.objectKey, CAST(fi.type AS string),
-               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
+               wm.id as wmId, m.name as wmName, m.profileImage as wmProfileImage
         FROM File fi
         JOIN WorkspaceMember wm ON fi.workspaceMemberId = wm.id
         JOIN wm.member m
@@ -290,7 +290,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 휴지통 파일 조회 (alphabet 정렬)
     @Query("""
         SELECT fi.id, fi.name, fi.createdAt, fi.updatedAt, fi.size, fi.objectKey, CAST(fi.type AS string),
-               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
+               wm.id as wmId, m.name as wmName, m.profileImage as wmProfileImage
         FROM File fi
         JOIN WorkspaceMember wm ON fi.workspaceMemberId = wm.id
         JOIN wm.member m

--- a/src/main/java/com/project/syncly/domain/folder/repository/FolderRepository.java
+++ b/src/main/java/com/project/syncly/domain/folder/repository/FolderRepository.java
@@ -68,9 +68,10 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 특정 폴더의 하위 폴더 목록 조회 (워크스페이스 멤버 정보 포함)
     @Query("""
         SELECT f.id, f.name, f.createdAt, f.updatedAt,
-               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
         FROM Folder f
         JOIN WorkspaceMember wm ON f.workspaceMemberId = wm.id
+        JOIN wm.member m
         WHERE f.parentId = :folderId
         AND f.deletedAt IS NULL
         AND (:search IS NULL OR f.name LIKE %:search%)
@@ -87,9 +88,10 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 특정 폴더의 파일 목록 조회 (워크스페이스 멤버 정보 포함)
     @Query("""
         SELECT fi.id, fi.name, fi.createdAt, fi.updatedAt, fi.size, fi.objectKey, CAST(fi.type AS string),
-               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
         FROM File fi
         JOIN WorkspaceMember wm ON fi.workspaceMemberId = wm.id
+        JOIN wm.member m
         WHERE fi.folderId = :folderId
         AND fi.deletedAt IS NULL
         AND (:search IS NULL OR fi.name LIKE %:search%)
@@ -106,9 +108,10 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 폴더 조회 (latest 정렬)
     @Query("""
         SELECT f.id, f.name, f.createdAt, f.updatedAt,
-               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
         FROM Folder f
         JOIN WorkspaceMember wm ON f.workspaceMemberId = wm.id
+        JOIN wm.member m
         WHERE f.parentId = :folderId
         AND f.deletedAt IS NULL
         AND (:search IS NULL OR f.name LIKE %:search%)
@@ -125,9 +128,10 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 폴더 조회 (alphabet 정렬)
     @Query("""
         SELECT f.id, f.name, f.createdAt, f.updatedAt,
-               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
         FROM Folder f
         JOIN WorkspaceMember wm ON f.workspaceMemberId = wm.id
+        JOIN wm.member m
         WHERE f.parentId = :folderId
         AND f.deletedAt IS NULL
         AND (:search IS NULL OR f.name LIKE %:search%)
@@ -144,9 +148,10 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 파일 조회 (latest 정렬)
     @Query("""
         SELECT fi.id, fi.name, fi.createdAt, fi.updatedAt, fi.size, fi.objectKey, CAST(fi.type AS string),
-               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
         FROM File fi
         JOIN WorkspaceMember wm ON fi.workspaceMemberId = wm.id
+        JOIN wm.member m
         WHERE fi.folderId = :folderId
         AND fi.deletedAt IS NULL
         AND (:search IS NULL OR fi.name LIKE %:search%)
@@ -163,9 +168,10 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 파일 조회 (alphabet 정렬)
     @Query("""
         SELECT fi.id, fi.name, fi.createdAt, fi.updatedAt, fi.size, fi.objectKey, CAST(fi.type AS string),
-               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
         FROM File fi
         JOIN WorkspaceMember wm ON fi.workspaceMemberId = wm.id
+        JOIN wm.member m
         WHERE fi.folderId = :folderId
         AND fi.deletedAt IS NULL
         AND (:search IS NULL OR fi.name LIKE %:search%)
@@ -182,9 +188,10 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 워크스페이스 휴지통 - 삭제된 폴더 목록 조회 (워크스페이스 멤버 정보 포함)
     @Query("""
         SELECT f.id, f.name, f.createdAt, f.updatedAt,
-               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
         FROM Folder f
         JOIN WorkspaceMember wm ON f.workspaceMemberId = wm.id
+        JOIN wm.member m
         WHERE f.workspaceId = :workspaceId
         AND f.deletedAt IS NOT NULL
         AND (:search IS NULL OR f.name LIKE %:search%)
@@ -201,9 +208,10 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 워크스페이스 휴지통 - 삭제된 파일 목록 조회 (워크스페이스 멤버 정보 포함)
     @Query("""
         SELECT fi.id, fi.name, fi.createdAt, fi.updatedAt, fi.size, fi.objectKey, CAST(fi.type AS string),
-               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
         FROM File fi
         JOIN WorkspaceMember wm ON fi.workspaceMemberId = wm.id
+        JOIN wm.member m
         JOIN Folder f ON fi.folderId = f.id
         WHERE f.workspaceId = :workspaceId
         AND fi.deletedAt IS NOT NULL
@@ -221,9 +229,10 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 휴지통 폴더 조회 (latest 정렬)
     @Query("""
         SELECT f.id, f.name, f.createdAt, f.updatedAt,
-               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
         FROM Folder f
         JOIN WorkspaceMember wm ON f.workspaceMemberId = wm.id
+        JOIN wm.member m
         WHERE f.workspaceId = :workspaceId
         AND f.deletedAt IS NOT NULL
         AND (:search IS NULL OR f.name LIKE %:search%)
@@ -240,9 +249,10 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 휴지통 폴더 조회 (alphabet 정렬)
     @Query("""
         SELECT f.id, f.name, f.createdAt, f.updatedAt,
-               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
         FROM Folder f
         JOIN WorkspaceMember wm ON f.workspaceMemberId = wm.id
+        JOIN wm.member m
         WHERE f.workspaceId = :workspaceId
         AND f.deletedAt IS NOT NULL
         AND (:search IS NULL OR f.name LIKE %:search%)
@@ -259,9 +269,10 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 휴지통 파일 조회 (latest 정렬)
     @Query("""
         SELECT fi.id, fi.name, fi.createdAt, fi.updatedAt, fi.size, fi.objectKey, CAST(fi.type AS string),
-               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
         FROM File fi
         JOIN WorkspaceMember wm ON fi.workspaceMemberId = wm.id
+        JOIN wm.member m
         JOIN Folder f ON fi.folderId = f.id
         WHERE f.workspaceId = :workspaceId
         AND fi.deletedAt IS NOT NULL
@@ -279,9 +290,10 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 커서 기반 페이징을 위한 휴지통 파일 조회 (alphabet 정렬)
     @Query("""
         SELECT fi.id, fi.name, fi.createdAt, fi.updatedAt, fi.size, fi.objectKey, CAST(fi.type AS string),
-               wm.id as wmId, wm.name as wmName, wm.member.profileImage as wmProfileImage
+               wm.id as wmId, wm.name as wmName, m.profileImage as wmProfileImage
         FROM File fi
         JOIN WorkspaceMember wm ON fi.workspaceMemberId = wm.id
+        JOIN wm.member m
         JOIN Folder f ON fi.folderId = f.id
         WHERE f.workspaceId = :workspaceId
         AND fi.deletedAt IS NOT NULL

--- a/src/main/java/com/project/syncly/domain/folder/service/FolderQueryServiceImpl.java
+++ b/src/main/java/com/project/syncly/domain/folder/service/FolderQueryServiceImpl.java
@@ -9,7 +9,6 @@ import com.project.syncly.domain.folder.exception.FolderException;
 import com.project.syncly.domain.folder.repository.FolderRepository;
 import com.project.syncly.domain.folder.repository.FolderClosureRepository;
 import com.project.syncly.domain.workspace.repository.WorkspaceRepository;
-import com.project.syncly.domain.workspaceMember.repository.WorkspaceMemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;

--- a/src/main/java/com/project/syncly/domain/s3/enums/FileMimeType.java
+++ b/src/main/java/com/project/syncly/domain/s3/enums/FileMimeType.java
@@ -29,6 +29,14 @@ public enum FileMimeType implements BaseEnum {
     FLV("video/x-flv", "flv"),
     WEBM("video/webm", "webm"),
 
+    // 오디오 파일
+    MP3("audio/mpeg", "mp3"),
+    WAV("audio/wav", "wav"),
+    OGG("audio/ogg", "ogg"),
+    M4A("audio/mp4", "m4a"),
+    FLAC("audio/flac", "flac"),
+    AAC("audio/aac", "aac"),
+
     // 문서 파일
     PDF("application/pdf", "pdf"),
     DOC("application/msword", "doc"),
@@ -38,6 +46,43 @@ public enum FileMimeType implements BaseEnum {
     PPT("application/vnd.ms-powerpoint", "ppt"),
     PPTX("application/vnd.openxmlformats-officedocument.presentationml.presentation", "pptx"),
     TXT("text/plain", "txt"),
+    RTF("application/rtf", "rtf"),
+    CSV("text/csv", "csv"),
+    HWP("application/x-hwp", "hwp"),
+    HWPX("application/hwp+zip", "hwpx"),
+
+    // 압축 파일
+    ZIP("application/zip", "zip"),
+    RAR("application/vnd.rar", "rar"),
+    TAR("application/x-tar", "tar"),
+    GZ("application/gzip", "gz"),
+    SEVENZ("application/x-7z-compressed", "7z"),
+
+    // 코드/개발 파일
+    JSON("application/json", "json"),
+    XML("application/xml", "xml"),
+    HTML("text/html", "html"),
+    CSS("text/css", "css"),
+    JS("text/javascript", "js"),
+    TS("text/typescript", "ts"),
+    JSX("text/jsx", "jsx"),
+    TSX("text/tsx", "tsx"),
+    JAVA("text/x-java-source", "java"),
+    PY("text/x-python", "py"),
+    CPP("text/x-c++src", "cpp"),
+    C("text/x-csrc", "c"),
+    SH("application/x-sh", "sh"),
+    MD("text/markdown", "md"),
+    YML("application/x-yaml", "yml"),
+    YAML("application/x-yaml", "yaml"),
+
+    // 기타
+    SQL("application/sql", "sql"),
+    EXE("application/vnd.microsoft.portable-executable", "exe"),
+    APK("application/vnd.android.package-archive", "apk"),
+    IPA("application/octet-stream", "ipa"),
+    DMG("application/x-apple-diskimage", "dmg"),
+    ISO("application/x-iso9660-image", "iso"),
     ;
 
     private final String key;
@@ -75,6 +120,14 @@ public enum FileMimeType implements BaseEnum {
             case "flv" -> FLV;
             case "webm" -> WEBM;
 
+            // 오디오 파일
+            case "mp3" -> MP3;
+            case "wav" -> WAV;
+            case "ogg" -> OGG;
+            case "m4a" -> M4A;
+            case "flac" -> FLAC;
+            case "aac" -> AAC;
+
             // 문서 파일
             case "pdf" -> PDF;
             case "doc" -> DOC;
@@ -84,6 +137,43 @@ public enum FileMimeType implements BaseEnum {
             case "ppt" -> PPT;
             case "pptx" -> PPTX;
             case "txt" -> TXT;
+            case "rtf" -> RTF;
+            case "csv" -> CSV;
+            case "hwp" -> HWP;
+            case "hwpx" -> HWPX;
+
+            // 압축 파일
+            case "zip" -> ZIP;
+            case "rar" -> RAR;
+            case "tar" -> TAR;
+            case "gz" -> GZ;
+            case "7z" -> SEVENZ;
+
+            // 코드/개발 파일
+            case "json" -> JSON;
+            case "xml" -> XML;
+            case "html" -> HTML;
+            case "css" -> CSS;
+            case "js" -> JS;
+            case "ts" -> TS;
+            case "jsx" -> JSX;
+            case "tsx" -> TSX;
+            case "java" -> JAVA;
+            case "py" -> PY;
+            case "cpp" -> CPP;
+            case "c" -> C;
+            case "sh" -> SH;
+            case "md" -> MD;
+            case "yml" -> YML;
+            case "yaml" -> YAML;
+
+            // 기타
+            case "sql" -> SQL;
+            case "exe" -> EXE;
+            case "apk" -> APK;
+            case "ipa" -> IPA;
+            case "dmg" -> DMG;
+            case "iso" -> ISO;
 
             default -> TXT; // 알 수 없는 확장자는 text/plain으로 처리 (개발 단계)
         };

--- a/src/main/java/com/project/syncly/domain/s3/enums/FileMimeType.java
+++ b/src/main/java/com/project/syncly/domain/s3/enums/FileMimeType.java
@@ -54,7 +54,7 @@ public enum FileMimeType implements BaseEnum {
         return expected;
     }
 
-    // 확장자 -> mime
+    // 확장자 -> mime (개발 단계: 모든 확장자 허용, 매칭되지 않으면 octet-stream으로 처리)
     public static FileMimeType fromExtension(String ext) {
         return switch (ext.toLowerCase()) {
             // 이미지 파일
@@ -85,7 +85,7 @@ public enum FileMimeType implements BaseEnum {
             case "pptx" -> PPTX;
             case "txt" -> TXT;
 
-            default -> throw new S3Exception(S3ErrorCode.UNSUPPORTED_FILE_EXTENSION);
+            default -> TXT; // 알 수 없는 확장자는 text/plain으로 처리 (개발 단계)
         };
     }
 

--- a/src/main/java/com/project/syncly/domain/workspace/dto/WorkspaceMemberInfoResponseDto.java
+++ b/src/main/java/com/project/syncly/domain/workspace/dto/WorkspaceMemberInfoResponseDto.java
@@ -10,6 +10,7 @@ public record WorkspaceMemberInfoResponseDto(
         Long workspaceMemberId,
         String memberName,
         String memberEmail,
+        String memberObjectKey,
         Role role,
         LocalDateTime joinedAt
 ) {}

--- a/src/main/java/com/project/syncly/domain/workspaceMember/repository/WorkspaceMemberRepository.java
+++ b/src/main/java/com/project/syncly/domain/workspaceMember/repository/WorkspaceMemberRepository.java
@@ -45,6 +45,7 @@ public interface WorkspaceMemberRepository extends JpaRepository<WorkspaceMember
             wm.id,
             m.name,
             m.email,
+            m.profileImage,
             wm.role,
             wm.createdAt
         )

--- a/src/main/java/com/project/syncly/global/validator/FileNameValidator.java
+++ b/src/main/java/com/project/syncly/global/validator/FileNameValidator.java
@@ -6,9 +6,9 @@ import jakarta.validation.ConstraintValidatorContext;
 
 public class FileNameValidator implements ConstraintValidator<ValidFileName, String> {
 
-    //한글/영문/기호/확장자 포함
+    //한글/영문/기호/확장자 포함 (개발 단계: 모든 확장자 허용)
     private static final String FILE_NAME_REGEX =
-            "^[\\p{L}\\p{N} _\\-().\\[\\]]{1,100}\\.(jpg|jpeg|png|gif|bmp|svg|webp|mp4|avi|mkv|mov|wmv|flv|webm|pdf|doc|docx|xls|xlsx|ppt|pptx|txt|hwp)$";
+            "^[\\p{L}\\p{N} _\\-().\\[\\]]{1,100}\\.[a-zA-Z0-9]{1,10}$";
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {

--- a/src/main/java/com/project/syncly/global/validator/FileNameValidator.java
+++ b/src/main/java/com/project/syncly/global/validator/FileNameValidator.java
@@ -6,12 +6,16 @@ import jakarta.validation.ConstraintValidatorContext;
 
 public class FileNameValidator implements ConstraintValidator<ValidFileName, String> {
 
-    //한글/영문/기호/확장자 포함 (개발 단계: 모든 확장자 허용)
+    // 개발 단계: 파일명 제한 완화 (확장자만 필수, 최대 255자)
     private static final String FILE_NAME_REGEX =
-            "^[\\p{L}\\p{N} _\\-().\\[\\]]{1,100}\\.[a-zA-Z0-9]{1,10}$";
+            "^.{1,255}\\..+$";
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
-        return value != null && value.matches(FILE_NAME_REGEX);
+        if (value == null || value.trim().isEmpty()) {
+            return false;
+        }
+        // 확장자가 있는지만 확인 (개발 단계)
+        return value.contains(".") && value.lastIndexOf('.') > 0 && value.lastIndexOf('.') < value.length() - 1;
     }
 }


### PR DESCRIPTION
# ☝️Issue Number
close #107 

##  📌 개요

- 팀원목록/채팅/파일폴더 api에서 object key 반환하도록 수정

## 🔁 변경 사항
[fix: 채팅 get 반환 시 유저의 프로필 이미지 포함하도록](https://github.com/SynclyProject/Syncly-BE/commit/f3de7283a3d18982563baf06bf221d09920ed26d)

[fix: 워크스페이스 유저 목록 반환 시 유저의 프로필 이미지 포함하도록](https://github.com/SynclyProject/Syncly-BE/commit/b739851d51c562e6a377367f0c7b858eddbc9fab)

[fix: 파일/폴더 목록 반환 시 유저의 오브젝트 키 반환하도록](https://github.com/SynclyProject/Syncly-BE/commit/2782bdc80fd6e870eb76fa5664b3bc216fa883a1)

[refactor: 파일 확장자 임시 확장](https://github.com/SynclyProject/Syncly-BE/commit/118f02c2344f88e53784c31d8d3df3ec434d5d8c)

[fix: 파일/폴더 API의 사용자 정보 매핑 오류 수정](https://github.com/SynclyProject/Syncly-BE/commit/55798ff58d0d535d71d7f5b0196d9bc1049e1d2a)

[refactor: 파일 이름 제한 완화 (개발단계이므로)](https://github.com/SynclyProject/Syncly-BE/commit/ed953ab3fa527835044b5c95342f6b31c628b7f7)

[fix: 파일 확장자 제한 완화 및 enum에 확장자 추가](https://github.com/SynclyProject/Syncly-BE/commit/a442828ebed79c842521fc5ee6730edf3425dece)

## 📸 스크린샷


## 👀 기타 더 이야기해볼 점
- 현재 hwp 파일 업로드 시 presigned url 403에러뜨는걸 확인해봐야함