### PR TITLE
🐛 fix: 채팅 메시지 WebSocket에서 sender 프로필 이미지 NULL 문제 해결

### DIFF
--- a/src/main/java/com/project/syncly/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/com/project/syncly/domain/chat/converter/ChatConverter.java
@@ -27,7 +27,7 @@ public class ChatConverter {
                 .workspaceId(chatMessage.getWorkspace().getId())
                 .senderId(chatMessage.getSender().getId())
                 .senderName(chatMessage.getSender().getName())
-                .senderProfileImage(chatMessage.getSender().getProfileImage())
+                .senderProfileImage(chatMessage.getSender().getMember().getProfileImage())
                 .msgId(chatMessage.getMsgId())
                 .seq(chatMessage.getSeq())
                 .content(chatMessage.getContent())

--- a/src/main/java/com/project/syncly/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/project/syncly/domain/chat/repository/ChatMessageRepository.java
@@ -43,6 +43,16 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 
     @Query("SELECT COALESCE(MAX(m.seq),0) FROM ChatMessage m WHERE m.workspace.id=:ws")
     Long findLatestSeq(@Param("ws") Long wsId);
+
+    @Query("""
+    SELECT cm 
+    FROM ChatMessage cm
+    JOIN FETCH cm.sender ws
+    JOIN FETCH ws.member m
+    WHERE cm.id = :id
+    """)
+    Optional<ChatMessage> findByIdWithSenderAndMember(@Param("id") Long id);
+
 }
 
 

--- a/src/main/java/com/project/syncly/domain/chat/service/ChatWebSocketServiceImpl.java
+++ b/src/main/java/com/project/syncly/domain/chat/service/ChatWebSocketServiceImpl.java
@@ -78,6 +78,9 @@ public class ChatWebSocketServiceImpl implements ChatWebSocketService {
         ChatMessage chatMessage = ChatConverter.toChatMessage(workspace, sender, request.msgId(), seq, request.content());
         chatRepository.save(chatMessage);
 
-        return ChatConverter.toChatMessageResponse(chatMessage);
+        ChatMessage loadedMessage = chatRepository.findByIdWithSenderAndMember(chatMessage.getId())
+                .orElseThrow(() -> new CustomException(WorkspaceErrorCode.WORKSPACE_NOT_FOUND));
+
+        return ChatConverter.toChatMessageResponse(loadedMessage);
     }
 }


### PR DESCRIPTION
# ☝️Issue Number
close #113 

##  📌 개요
문제: WebSocket을 통해 채팅 메시지를 조회할 때, ChatMessage.sender.member.profileImage가 null로 반환됨.

원인: JPA에서 sender → member 관계가 LAZY로 설정되어 있어, 세션 종료 후 접근 시 프록시 초기화 오류가 발생하고, 결과적으로 프로필 이미지가 정상적으로 로딩되지 않음.

해결: ChatMessageRepository에 fetch join 쿼리(findByIdWithSenderAndMember)를 추가하여, 메시지 조회 시 sender와 member를 함께 로딩하도록 수정.

영향: 채팅 WebSocket 및 HTTP 응답에서 sender의 프로필 이미지가 정상적으로 반환됨.



## 🔁 변경 사항

repository 수정
service 수정


## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
- 시간 오류는 ec2 region 문제인 것 같습니다 로컬에서는 잘 되네요