### PR TITLE
♻️ refactor: 폴더 이름 중복 로직 추가

### DIFF
--- a/.github/pull_request-template.md
+++ b/.github/pull_request-template.md
@@ -1,5 +1,5 @@
 # ☝️Issue Number
-close # 이슈번호
+closes # 이슈번호
 
 ##  📌 개요
 

--- a/src/main/java/com/project/syncly/domain/folder/service/FolderCommandServiceImpl.java
+++ b/src/main/java/com/project/syncly/domain/folder/service/FolderCommandServiceImpl.java
@@ -92,13 +92,11 @@ public class FolderCommandServiceImpl implements FolderCommandService{
             }
         }
 
-        // [4] 같은 부모 안에 동일한 이름의 폴더 존재하는지 확인
-        if (folderRepository.existsByWorkspaceIdAndParentIdAndName(workspaceId, parentId, requestDto.name())) {
-            throw new FolderException(FolderErrorCode.DUPLICATE_FOLDER_NAME);
-        }
+        // [4] 같은 부모 안에 중복되지 않는 고유한 폴더명 생성
+        String uniqueFolderName = generateUniqueFolderName(workspaceId, parentId, requestDto.name());
 
         // [5] 폴더 생성 - parentId를 업데이트된 값으로 사용, 올바른 workspaceMemberId 사용
-        FolderRequestDto.Create updatedRequestDto = new FolderRequestDto.Create(parentId, requestDto.name());
+        FolderRequestDto.Create updatedRequestDto = new FolderRequestDto.Create(parentId, uniqueFolderName);
         Folder folder = folderRepository.save(FolderConverter.toFolder(workspaceId, updatedRequestDto, workspaceMember.getId()));
         folderClosureCommandService.updateOnCreate(parentId, folder.getId());
         return FolderConverter.toFolderResponse(folder);
@@ -352,6 +350,19 @@ public class FolderCommandServiceImpl implements FolderCommandService{
         log.info("Folder {} and {} descendants hard deleted successfully", folderId, descendantFolderIds.size() - 1);
 
         return new FolderResponseDto.Message("폴더가 완전히 삭제되었습니다.");
+    }
+
+    // 같은 부모 폴더 내에서 중복되지 않는 고유한 폴더명 생성 (1), (2) .. 순차 증가
+    private String generateUniqueFolderName(Long workspaceId, Long parentId, String originalName) {
+        String uniqueName = originalName;
+        int counter = 1;
+
+        while (folderRepository.existsByWorkspaceIdAndParentIdAndNameAndDeletedAtIsNull(workspaceId, parentId, uniqueName)) {
+            uniqueName = originalName + "(" + counter + ")";
+            counter++;
+        }
+
+        return uniqueName;
     }
 
     // 삭제된 폴더의 하위 폴더들을 재귀적으로 찾는 헬퍼 메서드


### PR DESCRIPTION
# ☝️Issue Number
closes #116 

##  📌 개요
- 바로 위 부모 폴더가 동일할 경우 이름이 중복되면 (1), (2) .. 카운터 처리하도록 로직을 수정했습니다.
- 바로 위 부모 폴더가 동일하지 않을 경우 이름 중복이 허용됩니다. (ex. 'A' 폴더 하위 폴더로 'A' 허용)

## 🔁 변경 사항
[refactor: folder 이름 중복 로직 구현](https://github.com/SynclyProject/Syncly-BE/commit/5644826131259a5ce28d31aea2d18572e0d7c9f5)
[chore: 이슈 자동으로 닫히도록 템플릿 수정](https://github.com/SynclyProject/Syncly-BE/commit/ac7e3fe2d8d2f09f84dbf95ba85184dace3d24e9)

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점