### PR TITLE
🐛 fix: WorkspaceMember 탈퇴 및 추방 시 ChatMessage의 외래 키 제약 조건으로 인한 삭제 실패 문…

### DIFF
--- a/src/main/java/com/project/syncly/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/com/project/syncly/domain/chat/converter/ChatConverter.java
@@ -22,12 +22,14 @@ public class ChatConverter {
     }
 
     public static ChatWebSocketResponseDto.ChatResponseDto toChatMessageResponse(ChatMessage chatMessage) {
+        WorkspaceMember sender = chatMessage.getSender();
+
         return ChatWebSocketResponseDto.ChatResponseDto.builder()
                 .id(chatMessage.getId())
                 .workspaceId(chatMessage.getWorkspace().getId())
-                .senderId(chatMessage.getSender().getId())
-                .senderName(chatMessage.getSender().getName())
-                .senderProfileImage(chatMessage.getSender().getProfileImage())
+                .senderId(sender != null ? sender.getId() : null)
+                .senderName(sender != null ? sender.getName() : "탈퇴한 사용자")
+                .senderProfileImage(sender != null ? sender.getProfileImage() : null)
                 .msgId(chatMessage.getMsgId())
                 .seq(chatMessage.getSeq())
                 .content(chatMessage.getContent())

--- a/src/main/java/com/project/syncly/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/project/syncly/domain/chat/entity/ChatMessage.java
@@ -31,7 +31,7 @@ public class ChatMessage extends BaseCreatedEntity {
     private Workspace workspace;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "sender_id", nullable = false)
+    @JoinColumn(name = "sender_id", nullable = true)
     private WorkspaceMember sender;
 
     @Column(name = "msg_id", nullable = false, length = 36)

--- a/src/main/java/com/project/syncly/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/project/syncly/domain/chat/repository/ChatMessageRepository.java
@@ -3,6 +3,7 @@ package com.project.syncly.domain.chat.repository;
 import com.project.syncly.domain.chat.entity.ChatMessage;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -45,13 +46,18 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     Long findLatestSeq(@Param("ws") Long wsId);
 
     @Query("""
-    SELECT cm 
+    SELECT cm
     FROM ChatMessage cm
     JOIN FETCH cm.sender ws
     JOIN FETCH ws.member m
     WHERE cm.id = :id
     """)
     Optional<ChatMessage> findByIdWithSenderAndMember(@Param("id") Long id);
+
+    // WorkspaceMember 삭제 전에 해당 멤버가 보낸 모든 메시지의 sender를 null로 설정
+    @Modifying
+    @Query("UPDATE ChatMessage cm SET cm.sender = null WHERE cm.sender.id = :workspaceMemberId")
+    void nullifySenderByWorkspaceMemberId(@Param("workspaceMemberId") Long workspaceMemberId);
 
 }
 

--- a/src/main/java/com/project/syncly/domain/workspace/service/WorkspaceServiceImpl.java
+++ b/src/main/java/com/project/syncly/domain/workspace/service/WorkspaceServiceImpl.java
@@ -1,5 +1,6 @@
 package com.project.syncly.domain.workspace.service;
 
+import com.project.syncly.domain.chat.repository.ChatMessageRepository;
 import com.project.syncly.domain.folder.service.FolderCommandService;
 import com.project.syncly.domain.member.entity.Member;
 import com.project.syncly.domain.member.repository.MemberRepository;
@@ -40,6 +41,7 @@ public class WorkspaceServiceImpl implements WorkspaceService {
     private final InvitationMailServiceImpl invitationMailService;
     private final SseServiceImpl sseService;
     private final FolderCommandService folderCommandService;
+    private final ChatMessageRepository chatMessageRepository;
 
 
     @Value("${spring.mail.invitation.link}")
@@ -322,20 +324,23 @@ public class WorkspaceServiceImpl implements WorkspaceService {
             nextManager.setRole(Role.MANAGER);
             workspaceMemberRepository.save(nextManager);
 
-            // 멤버 삭제
+            // 채팅 메시지의 sender를 null로 설정 후 멤버 삭제
+            chatMessageRepository.nullifySenderByWorkspaceMemberId(member.getId());
             workspaceMemberRepository.delete(member);
         }
 
         //나가고자 하는 사람이 매니저 일 경우 ( && 팀원이 매니저 포함 1명일 경우)
         else if (member.getRole() == Role.MANAGER) {
-            //멤버 삭제 후 워크 스페이스 삭제
+            // 채팅 메시지의 sender를 null로 설정 후 멤버 삭제 및 워크 스페이스 삭제
+            chatMessageRepository.nullifySenderByWorkspaceMemberId(member.getId());
             workspaceMemberRepository.delete(member);
             workspaceRepository.delete(workspace);
         }
 
         //CREW 일 경우
         else {
-            // 멤버 삭제
+            // 채팅 메시지의 sender를 null로 설정 후 멤버 삭제
+            chatMessageRepository.nullifySenderByWorkspaceMemberId(member.getId());
             workspaceMemberRepository.delete(member);
         }
 
@@ -378,7 +383,8 @@ public class WorkspaceServiceImpl implements WorkspaceService {
             throw new CustomException(WorkspaceErrorCode.NOT_WORKSPACE_CREW);
         }
 
-        // 멤버 삭제 (추방)
+        // 채팅 메시지의 sender를 null로 설정 후 멤버 삭제 (추방)
+        chatMessageRepository.nullifySenderByWorkspaceMemberId(targetMember.getId());
         workspaceMemberRepository.delete(targetMember);
 
         //반환


### PR DESCRIPTION
# ☝️Issue Number
close # 118

##  📌 개요

🐛 fix: WorkspaceMember 탈퇴/추방 시 외래 키 제약 조건 오류 수정

워크스페이스 멤버가 탈퇴하거나 추방될 때, ChatMessage 엔티티와의 외래 키 제약 조건으로 인해 삭제가 실패하는 버그 수정


## 🔁 변경 사항

sender 필드를 nullable = true로 변경
멤버 삭제 전에 해당 멤버가 보낸 모든 메시지의 sender를 null로 설정
클라이언트에서는 "탈퇴한 사용자"로 표시

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점