### PR TITLE
🐛 fix: 탈퇴한 사용자 재초대 시 중복 초대 조회 오류 수정

### DIFF
--- a/src/main/java/com/project/syncly/domain/workspace/repository/WorkspaceInvitationRepository.java
+++ b/src/main/java/com/project/syncly/domain/workspace/repository/WorkspaceInvitationRepository.java
@@ -17,6 +17,9 @@ public interface WorkspaceInvitationRepository extends JpaRepository<WorkspaceIn
     //이미 보댄 초대가 있다면, 조회
     Optional<WorkspaceInvitation> findByWorkspaceIdAndInviteeIdAndExpiredAtAfter(Long workspaceId, Long inviteeId, LocalDateTime now);
 
+    //PENDING 상태의 초대만 조회 (탈퇴 후 재초대 시 중복 방지)
+    Optional<WorkspaceInvitation> findByWorkspaceIdAndInviteeIdAndTypeAndExpiredAtAfter(Long workspaceId, Long inviteeId, InvitationType type, LocalDateTime now);
+
     //토큰으로 초대 조회
     Optional<WorkspaceInvitation> findByToken(String token);
 

--- a/src/main/java/com/project/syncly/domain/workspace/service/WorkspaceServiceImpl.java
+++ b/src/main/java/com/project/syncly/domain/workspace/service/WorkspaceServiceImpl.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional
@@ -137,16 +138,13 @@ public class WorkspaceServiceImpl implements WorkspaceService {
             throw new CustomException(WorkspaceErrorCode.ALREADY_WORKSPACE_MEMBER);
         }
 
-        // 아직 만료되지 않은 초대가 있는지 확인
-        boolean hasActiveInvite = workspaceInvitationRepository.existsByWorkspaceIdAndInviteeIdAndExpiredAtAfter(
-                workspaceId, invitee.getId(), LocalDateTime.now());
-        if (hasActiveInvite) {
-            //초대 만료 전 초대가 존재하나, 멤버가 그룹에 포함되어 있지 않으면서 ACCEPT or REJECT 상태라면 재전송 가능
-            WorkspaceInvitation invited = workspaceInvitationRepository.findByWorkspaceIdAndInviteeIdAndExpiredAtAfter(workspaceId, invitee.getId(), LocalDateTime.now())
-                    .orElseThrow(() -> new CustomException(WorkspaceErrorCode.INVITATION_NOT_FOUND));
-            if (invited.getType() == InvitationType.PENDING) {
-                throw new CustomException(WorkspaceErrorCode.ALREADY_INVITED);
-            }
+        // PENDING 상태이면서 아직 만료되지 않은 초대가 있는지 확인
+        Optional<WorkspaceInvitation> pendingInvitation = workspaceInvitationRepository
+                .findByWorkspaceIdAndInviteeIdAndTypeAndExpiredAtAfter(
+                        workspaceId, invitee.getId(), InvitationType.PENDING, LocalDateTime.now());
+
+        if (pendingInvitation.isPresent()) {
+            throw new CustomException(WorkspaceErrorCode.ALREADY_INVITED);
         }
 
         // 초대 토큰 생성 (invitationMailService 에서 중복 여부 확인)


### PR DESCRIPTION
# ☝️Issue Number
close #120 

##  📌 개요

- WorkspaceServiceImpl.java:145 - 중복 결과 반환으로 인한 예외 발생
해결 방법
PENDING 상태의 초대만 조회하도록 개선:


## 🔁 변경 사항
- WorkspaceInvitationRepository에 PENDING 상태 필터링 메소드 추가
- WorkspaceServiceImpl.inviteTeamWorkspace()에서 PENDING 상태만 확인하도록
수정

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점