### PR TITLE
refactor : 채팅에서 프로필 이미지가 보이지 않는 오류 해결

### DIFF
--- a/src/main/java/com/project/syncly/domain/workspaceMember/converter/WorkspaceMemberConverter.java
+++ b/src/main/java/com/project/syncly/domain/workspaceMember/converter/WorkspaceMemberConverter.java
@@ -15,6 +15,7 @@ public class WorkspaceMemberConverter {
                 .member(member)
                 .role(Role.MANAGER)
                 .name(memberName)
+                .profileImage(member.getProfileImage())
                 .build();
     }
 
@@ -25,6 +26,7 @@ public class WorkspaceMemberConverter {
                 .member(member)
                 .role(Role.CREW)
                 .name(memberName)
+                .profileImage(member.getProfileImage())
                 .build();
     }
 


### PR DESCRIPTION
# ☝️Issue Number
closes # 이슈번호

##  📌 개요

- 프로필 이미지 변경 시, 수정하긴 하나, 새로운 워크스페이스 만들때 프로필 이미지를 갖고오지 않는 오류가 있었음.

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점