### PR TITLE
hotfix : 일부 프로필 이미지가 읽어지지 않던 오류 해결.

### DIFF
--- a/src/main/java/com/project/syncly/domain/s3/service/S3ServiceImpl.java
+++ b/src/main/java/com/project/syncly/domain/s3/service/S3ServiceImpl.java
@@ -49,7 +49,7 @@ public class S3ServiceImpl implements S3Service {
 
     @Override
     public ResponseEntity<Void> generateSignedCookieForView(S3RequestDTO.GetViewUrl request, HttpServletResponse response) {
-        String resourcePath = request.objectKey();
+        String resourcePath = "uploads/*";
 
         Map<String, String> cookies = cloudFrontUtil.generateSignedCookies(resourcePath, Duration.ofMinutes(10));
 


### PR DESCRIPTION
signed cookie 의 인가 범위를 파일로 특정하여, 그 이후의 파일을 읽을 수 없던 버그 해결

# ☝️Issue Number
closes # 이슈번호

##  📌 개요

- signedCookie의 인가 폴더 범위를 "uploads/" 로 확장

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점